### PR TITLE
Merge mlx-swift-structured into Cast as internal targets

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,6 +19,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          submodules: recursive
 
       - name: Setup Xcode
         uses: maxim-lobanov/setup-xcode@v1

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "Sources/CMLXStructured/xgrammar"]
+	path = Sources/CMLXStructured/xgrammar
+	url = https://github.com/mlc-ai/xgrammar

--- a/Package.swift
+++ b/Package.swift
@@ -13,14 +13,50 @@ let package = Package(
         .library(name: "Cast", targets: ["Cast"]),
     ],
     dependencies: [
-        // MLX Swift
-        .package(url: "https://github.com/ml-explore/mlx-swift.git", .upToNextMinor(from: "0.30.6")),
-        .package(url: "https://github.com/ml-explore/mlx-swift-lm.git", .upToNextMinor(from: "0.30.6")),
-        // SwiftSyntax for macros
+        .package(url: "https://github.com/ml-explore/mlx-swift.git", from: "0.30.2"),
+        .package(url: "https://github.com/ml-explore/mlx-swift-lm.git", from: "2.30.0"),
+        .package(url: "https://github.com/huggingface/swift-transformers.git", from: "1.1.0"),
+        .package(url: "https://github.com/petrukha-ivan/swift-json-schema.git", from: "2.0.2"),
         .package(url: "https://github.com/swiftlang/swift-syntax.git", from: "600.0.0"),
     ],
     targets: [
-        // Macro implementation (compiler plugin)
+        .target(
+            name: "CMLXStructured",
+            exclude: [
+                "xgrammar/web",
+                "xgrammar/tests",
+                "xgrammar/3rdparty/cpptrace",
+                "xgrammar/3rdparty/googletest",
+                "xgrammar/3rdparty/dlpack/contrib",
+                "xgrammar/3rdparty/dlpack/apps",
+                "xgrammar/3rdparty/dlpack/cmake",
+                "xgrammar/3rdparty/dlpack/docs",
+                "xgrammar/3rdparty/dlpack/tests",
+                "xgrammar/3rdparty/picojson",
+                "xgrammar/cpp/nanobind",
+                "xgrammar/cpp/testing.cc",
+                "xgrammar/cpp/testing.h",
+            ],
+            cSettings: [
+                .headerSearchPath("xgrammar/include"),
+                .headerSearchPath("xgrammar/3rdparty/dlpack/include"),
+                .headerSearchPath("xgrammar/3rdparty/picojson"),
+            ],
+            cxxSettings: [
+                .headerSearchPath("xgrammar/include"),
+                .headerSearchPath("xgrammar/3rdparty/dlpack/include"),
+                .headerSearchPath("xgrammar/3rdparty/picojson"),
+            ]
+        ),
+        .target(
+            name: "MLXStructured",
+            dependencies: [
+                .target(name: "CMLXStructured"),
+                .product(name: "MLX", package: "mlx-swift"),
+                .product(name: "MLXLMCommon", package: "mlx-swift-lm"),
+                .product(name: "JSONSchema", package: "swift-json-schema"),
+            ]
+        ),
         .macro(
             name: "CastMacros",
             dependencies: [
@@ -28,18 +64,17 @@ let package = Package(
                 .product(name: "SwiftCompilerPlugin", package: "swift-syntax"),
             ]
         ),
-        // Main library
         .target(
             name: "Cast",
             dependencies: [
                 "CastMacros",
+                "MLXStructured",
                 .product(name: "MLX", package: "mlx-swift"),
                 .product(name: "MLXNN", package: "mlx-swift"),
                 .product(name: "MLXLLM", package: "mlx-swift-lm"),
                 .product(name: "MLXLMCommon", package: "mlx-swift-lm"),
             ]
         ),
-        // Tests
         .testTarget(
             name: "CastTests",
             dependencies: ["Cast"]
@@ -51,5 +86,13 @@ let package = Package(
                 .product(name: "SwiftSyntaxMacrosTestSupport", package: "swift-syntax"),
             ]
         ),
-    ]
+        .testTarget(
+            name: "MLXStructuredTests",
+            dependencies: [
+                "MLXStructured",
+                .product(name: "MLXLLM", package: "mlx-swift-lm"),
+            ]
+        ),
+    ],
+    cxxLanguageStandard: .gnucxx17
 )

--- a/Sources/CMLXStructured/error_handler.cpp
+++ b/Sources/CMLXStructured/error_handler.cpp
@@ -1,0 +1,13 @@
+#include "mlx_structured/error_handler.h"
+
+static error_handler_closure _error_handler;
+
+extern "C" void set_error_handler(error_handler_closure error_handler) {
+    _error_handler = error_handler;
+}
+
+extern "C" void catch_error(const char* error_message) {
+    if (_error_handler) {
+        _error_handler(error_message);
+    }
+}

--- a/Sources/CMLXStructured/grammar_compiler.cpp
+++ b/Sources/CMLXStructured/grammar_compiler.cpp
@@ -1,0 +1,85 @@
+#include "mlx_structured/error_handler.h"
+#include "mlx_structured/grammar_compiler.h"
+#include <xgrammar/matcher.h>
+
+using namespace xgrammar;
+
+extern "C" void* compile_ebnf_grammar(
+    void* tokenizer_info,
+    const char* ebnf_utf8,
+    size_t ebnf_len
+) {
+    try {
+        const std::string ebnf(ebnf_utf8, ebnf_len);
+        auto& tokenizer_info_ptr = *static_cast<TokenizerInfo*>(tokenizer_info);
+        auto* compiled_grammar_ptr = new CompiledGrammar(
+            GrammarCompiler(tokenizer_info_ptr).CompileGrammar(Grammar::FromEBNF(ebnf))
+        );
+        return compiled_grammar_ptr;
+    } catch (const std::exception& e) {
+        catch_error(e.what());
+        return nullptr;
+    }
+}
+
+extern "C" void* compile_regex_grammar(
+    void* tokenizer_info,
+    const char* regex_utf8,
+    size_t regex_len
+) {
+    try {
+        const std::string regex(regex_utf8, regex_len);
+        auto& tokenizer_info_ptr = *static_cast<TokenizerInfo*>(tokenizer_info);
+        auto* compiled_grammar_ptr = new CompiledGrammar(
+            GrammarCompiler(tokenizer_info_ptr).CompileRegex(regex)
+        );
+        return compiled_grammar_ptr;
+    } catch (const std::exception& e) {
+        catch_error(e.what());
+        return nullptr;
+    }
+}
+
+extern "C" void* compile_json_schema_grammar(
+    void* tokenizer_info,
+    const char* schema_utf8,
+    size_t schema_len,
+    int indent
+) {
+    try {
+        const std::string schema(schema_utf8, schema_len);
+        const std::optional<int> opt_indent = (indent >= 0) ? std::optional<int>(indent) : std::nullopt;
+        auto& tokenizer_info_ptr = *static_cast<TokenizerInfo*>(tokenizer_info);
+        auto* compiled_grammar_ptr = new CompiledGrammar(
+            GrammarCompiler(tokenizer_info_ptr).CompileJSONSchema(schema, false, opt_indent, std::nullopt, true, std::nullopt)
+        );
+        return compiled_grammar_ptr;
+    } catch (const std::exception& e) {
+        catch_error(e.what());
+        return nullptr;
+    }
+}
+
+extern "C" void* compile_structural_tag(
+    void* tokenizer_info,
+    const char* structural_tag_utf8,
+    size_t structural_tag_len
+) {
+    try {
+        const std::string structural_tag(structural_tag_utf8, structural_tag_len);
+        auto& tokenizer_info_ptr = *static_cast<TokenizerInfo*>(tokenizer_info);
+        auto* compiled_grammar_ptr = new CompiledGrammar(
+            GrammarCompiler(tokenizer_info_ptr).CompileStructuralTag(structural_tag)
+        );
+        return compiled_grammar_ptr;
+    } catch (const std::exception& e) {
+        catch_error(e.what());
+        return nullptr;
+    }
+}
+
+extern "C" void compiled_grammar_free(void* compiled_grammar) {
+    if (compiled_grammar) {
+        delete static_cast<CompiledGrammar*>(compiled_grammar);
+    }
+}

--- a/Sources/CMLXStructured/grammar_matcher.cpp
+++ b/Sources/CMLXStructured/grammar_matcher.cpp
@@ -1,0 +1,70 @@
+#include "mlx_structured/error_handler.h"
+#include "mlx_structured/grammar_matcher.h"
+#include <dlpack/dlpack.h>
+#include <xgrammar/matcher.h>
+
+using namespace xgrammar;
+
+extern "C" void* grammar_matcher_new(void* compiled_grammar) {
+    try {
+        auto* compiled_grammar_ptr = static_cast<CompiledGrammar*>(compiled_grammar);
+        auto* grammar_matcher_ptr = new GrammarMatcher(*compiled_grammar_ptr);
+        return grammar_matcher_ptr;
+    } catch (const std::exception& e) {
+        catch_error(e.what());
+        return nullptr;
+    }
+}
+
+extern "C" bool grammar_matcher_fill_next_token_bitmask(
+    void* grammar_matcher,
+    void* next_token_bitmask
+) {
+    try {
+        auto* grammar_matcher_ptr = static_cast<GrammarMatcher*>(grammar_matcher);
+        auto* next_token_bitmask_ptr = static_cast<DLTensor*>(next_token_bitmask);
+        return grammar_matcher_ptr->FillNextTokenBitmask(next_token_bitmask_ptr);
+    } catch (const std::exception& e) {
+        catch_error(e.what());
+        return false;
+    }
+}
+
+extern "C" bool grammar_matcher_accept_token(
+    void* grammar_matcher,
+    int32_t token_id
+) {
+    try {
+        auto* grammar_matcher_ptr = static_cast<GrammarMatcher*>(grammar_matcher);
+        return grammar_matcher_ptr->AcceptToken(token_id);
+    } catch (const std::exception& e) {
+        catch_error(e.what());
+        return false;
+    }
+}
+
+extern "C" void grammar_matcher_reset(void* grammar_matcher) {
+    try {
+        auto* grammar_matcher_ptr = static_cast<GrammarMatcher*>(grammar_matcher);
+        grammar_matcher_ptr->Reset();
+    } catch (const std::exception& e) {
+        catch_error(e.what());
+        return;
+    }
+}
+
+extern "C" bool grammar_matcher_is_terminated(void* grammar_matcher) {
+    try {
+        auto* grammar_matcher_ptr = static_cast<GrammarMatcher*>(grammar_matcher);
+        return grammar_matcher_ptr->IsTerminated();
+    } catch (const std::exception& e) {
+        catch_error(e.what());
+        return false;
+    }
+}
+
+extern "C" void grammar_matcher_free(void* grammar_matcher) {
+    if (grammar_matcher) {
+        delete static_cast<GrammarMatcher*>(grammar_matcher);
+    }
+}

--- a/Sources/CMLXStructured/include/mlx_structured.h
+++ b/Sources/CMLXStructured/include/mlx_structured.h
@@ -1,0 +1,4 @@
+#include "mlx_structured/error_handler.h"
+#include "mlx_structured/grammar_compiler.h"
+#include "mlx_structured/grammar_matcher.h"
+#include "mlx_structured/tokenizer_info.h"

--- a/Sources/CMLXStructured/include/mlx_structured/error_handler.h
+++ b/Sources/CMLXStructured/include/mlx_structured/error_handler.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <stdio.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef void (*error_handler_closure)(const char* error_message);
+
+void set_error_handler(error_handler_closure error_handler);
+
+void catch_error(const char* error_message);
+
+#ifdef __cplusplus
+}
+#endif

--- a/Sources/CMLXStructured/include/mlx_structured/grammar_compiler.h
+++ b/Sources/CMLXStructured/include/mlx_structured/grammar_compiler.h
@@ -1,0 +1,38 @@
+#pragma once
+
+#include <stdio.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void* compile_ebnf_grammar(
+    void* tokenizer_info,
+    const char* ebnf_utf8,
+    size_t ebnf_len
+);
+
+void* compile_regex_grammar(
+    void* tokenizer_info,
+    const char* regex_utf8,
+    size_t regex_len
+);
+
+void* compile_json_schema_grammar(
+    void* tokenizer_info,
+    const char* schema_utf8,
+    size_t schema_len,
+    int indent
+);
+
+void* compile_structural_tag(
+    void* tokenizer_info,
+    const char* structural_tag_utf8,
+    size_t structural_tag_len
+);
+
+void compiled_grammar_free(void* compiled_grammar);
+
+#ifdef __cplusplus
+}
+#endif

--- a/Sources/CMLXStructured/include/mlx_structured/grammar_matcher.h
+++ b/Sources/CMLXStructured/include/mlx_structured/grammar_matcher.h
@@ -1,0 +1,31 @@
+#pragma once
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdbool.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void* grammar_matcher_new(void* compiled_grammar);
+
+bool grammar_matcher_fill_next_token_bitmask(
+    void* grammar_matcher,
+    void* next_token_bitmask
+);
+
+bool grammar_matcher_accept_token(
+    void* grammar_matcher,
+    int32_t token_id
+);
+
+void grammar_matcher_reset(void* grammar_matcher);
+
+bool grammar_matcher_is_terminated(void* grammar_matcher);
+
+void grammar_matcher_free(void* grammar_matcher);
+
+#ifdef __cplusplus
+}
+#endif

--- a/Sources/CMLXStructured/include/mlx_structured/tokenizer_info.h
+++ b/Sources/CMLXStructured/include/mlx_structured/tokenizer_info.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include <stdio.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void* tokenizer_info_new(
+    const char* const* vocab, size_t vocab_size, const int vocab_type,
+    const int32_t* eos_tokens, size_t eos_tokens_size
+);
+
+void tokenizer_info_free(void* tokenizer_info);
+
+#ifdef __cplusplus
+}
+#endif

--- a/Sources/CMLXStructured/include/module.modulemap
+++ b/Sources/CMLXStructured/include/module.modulemap
@@ -1,0 +1,4 @@
+module CMLXStructured {
+    header "mlx_structured.h"
+    export *
+}

--- a/Sources/CMLXStructured/tokenizer_info.cpp
+++ b/Sources/CMLXStructured/tokenizer_info.cpp
@@ -1,0 +1,36 @@
+#include "mlx_structured/error_handler.h"
+#include "mlx_structured/tokenizer_info.h"
+#include <xgrammar/tokenizer_info.h>
+
+using namespace xgrammar;
+
+extern "C" void* tokenizer_info_new(
+    const char* const* vocab, size_t vocab_size, const int vocab_type,
+    const int32_t* eos_tokens, size_t eos_tokens_size
+) {
+    try {
+        std::vector<std::string> encoded_vocab;
+        encoded_vocab.reserve(vocab_size);
+        for (size_t i = 0; i < vocab_size; ++i) {
+            encoded_vocab.emplace_back(vocab[i]);
+        }
+        
+        std::vector<int32_t> stops;
+        stops.reserve(eos_tokens_size);
+        for (size_t i = 0; i < eos_tokens_size; ++i) {
+            stops.emplace_back(eos_tokens[i]);
+        }
+        
+        auto* tokenizer_info = new TokenizerInfo(encoded_vocab, VocabType(vocab_type), vocab_size, stops, false);
+        return tokenizer_info;
+    } catch (const std::exception& e) {
+        catch_error(e.what());
+        return nullptr;
+    }
+}
+
+extern "C" void tokenizer_info_free(void* tokenizer_info) {
+    if (tokenizer_info) {
+        delete static_cast<TokenizerInfo*>(tokenizer_info);
+    }
+}

--- a/Sources/MLXStructured/Backends/DLTensor.swift
+++ b/Sources/MLXStructured/Backends/DLTensor.swift
@@ -1,0 +1,61 @@
+//
+//  DLTensor.swift
+//  MLXStructured
+//
+//  Created by Ivan Petrukha on 15.09.2025.
+//
+
+import Foundation
+
+struct DLDevice {
+    
+    var deviceType: Int32
+    var deviceId: Int32
+    
+    public init(deviceType: Int32, deviceId: Int32) {
+        self.deviceType = deviceType
+        self.deviceId = deviceId
+    }
+}
+
+struct DLDataType {
+    
+    var code: UInt8
+    var bits: UInt8
+    var lanes: UInt16
+    
+    init(rawCode: UInt8, bits: UInt8, lanes: UInt16) {
+        self.code = rawCode
+        self.bits = bits
+        self.lanes = lanes
+    }
+}
+
+struct DLTensor {
+    
+    var data: UnsafeMutableRawPointer?
+    var device: DLDevice
+    var ndim: Int32
+    var dtype: DLDataType
+    var shape: UnsafeMutablePointer<Int64>?
+    var strides: UnsafeMutablePointer<Int64>?
+    var byteOffset: UInt64
+    
+    init(
+        data: UnsafeMutableRawPointer?,
+        device: DLDevice,
+        ndim: Int32,
+        dtype: DLDataType,
+        shape: UnsafeMutablePointer<Int64>?,
+        strides: UnsafeMutablePointer<Int64>?,
+        byteOffset: UInt64
+    ) {
+        self.data = data
+        self.device = device
+        self.ndim = ndim
+        self.dtype = dtype
+        self.shape = shape
+        self.strides = strides
+        self.byteOffset = byteOffset
+    }
+}

--- a/Sources/MLXStructured/Backends/XGrammar.swift
+++ b/Sources/MLXStructured/Backends/XGrammar.swift
@@ -1,0 +1,196 @@
+//
+//  XGrammar.swift
+//  MLXStructured
+//
+//  Created by Ivan Petrukha on 14.09.2025.
+//
+
+import Foundation
+import CMLXStructured
+import MLX
+
+enum XGrammarError: Error {
+    case emptyGrammar
+    case invalidGrammar(String)
+    case invalidVocab(String)
+    case unknown(String)
+}
+
+private let errorHandler = {
+    let handler = ErrorHandler()
+    set_error_handler(errorHandlerClosure)
+    return handler
+}()
+
+private let errorHandlerClosure: @convention(c) (UnsafePointer<CChar>?) -> Void = {
+    errorHandler.lastErrorMessage = $0.map {
+        String(cString: $0)
+    }
+}
+
+private class ErrorHandler: @unchecked Sendable {
+    let lock = NSLock()
+    var _lastErrorMessage: String? = nil
+    var lastErrorMessage: String? {
+        get { lock.withLock { _lastErrorMessage } }
+        set { lock.withLock { _lastErrorMessage = newValue } }
+    }
+}
+
+private extension XGrammar {
+    static var lastErrorMessage: String {
+        errorHandler.lastErrorMessage ?? "Unknown Error"
+    }
+}
+
+final class XGrammar {
+            
+    private let vocabSize: Int
+    private let bufferSize: Int
+    private let bitmap: MLXArray
+    private var bitmask: DLTensor
+    private let grammarMatcher: UnsafeMutableRawPointer?
+    
+    init(
+        vocab: [String],
+        vocabType: Int32 = 0,
+        stopTokenIds: [Int32] = [],
+        grammar: Grammar
+    ) throws {
+        let _ = errorHandler // Start capturing errors
+        let vocab = vocab.map { strdup($0) }
+        let tokenizerInfo = vocab.map({ UnsafePointer($0) }).withUnsafeBufferPointer { vocabBuffer in
+            stopTokenIds.withUnsafeBufferPointer { stopTokenIdsBuffer in
+                tokenizer_info_new(
+                    vocabBuffer.baseAddress,
+                    vocabBuffer.count,
+                    vocabType,
+                    stopTokenIdsBuffer.baseAddress,
+                    stopTokenIdsBuffer.count
+                )
+            }
+        }
+        
+        defer {
+            tokenizer_info_free(tokenizerInfo)
+            vocab.forEach {
+                free($0)
+            }
+        }
+        
+        guard let tokenizerInfo else {
+            throw XGrammarError.invalidVocab(XGrammar.lastErrorMessage)
+        }
+        
+        let compiledGrammar = switch grammar {
+        case _ where grammar.raw.isEmpty:
+            throw XGrammarError.emptyGrammar
+        case .ebnf(let ebnf):
+            ebnf.utf8CString.withUnsafeBufferPointer {
+                compile_ebnf_grammar(tokenizerInfo, $0.baseAddress, $0.count)
+            }
+        case .regex(let regex):
+            regex.utf8CString.withUnsafeBufferPointer {
+                compile_regex_grammar(tokenizerInfo, $0.baseAddress, $0.count)
+            }
+        case .schema(let schema, let indent):
+            schema.utf8CString.withUnsafeBufferPointer {
+                compile_json_schema_grammar(tokenizerInfo, $0.baseAddress, $0.count, Int32(indent ?? -1))
+            }
+        case .structural(let tag):
+            tag.utf8CString.withUnsafeBufferPointer {
+                compile_structural_tag(tokenizerInfo, $0.baseAddress, $0.count)
+            }
+        }
+        
+        defer {
+            compiled_grammar_free(compiledGrammar)
+        }
+        
+        guard let compiledGrammar else {
+            throw XGrammarError.invalidGrammar(XGrammar.lastErrorMessage)
+        }
+        
+        var bitmap = [Float](repeating: 0, count: 256 * 8)
+        for b in 0..<256 {
+            for k in 0..<8 {
+                bitmap[b * 8 + k] = ((b >> k) & 1) == 1 ? 0 : -Float.infinity
+            }
+        }
+        
+        guard let grammarMatcher = grammar_matcher_new(compiledGrammar) else {
+            throw XGrammarError.unknown(XGrammar.lastErrorMessage)
+        }
+        
+        self.vocabSize = vocab.count
+        self.bufferSize = (vocab.count + 31) / 32
+        self.bitmap = MLXArray(bitmap).reshaped([256, 8])
+        self.bitmask = DLTensor.nextTokenBitmask(bufferSize: bufferSize)
+        self.grammarMatcher = grammarMatcher
+    }
+    
+    deinit {
+        bitmask.data?.deallocate()
+        bitmask.shape?.deallocate()
+        bitmask.strides?.deallocate()
+        grammar_matcher_free(grammarMatcher)
+    }
+}
+
+extension XGrammar: GrammarMatcher {
+    
+    func nextTokenMask() -> MLXArray {
+        guard withUnsafeMutablePointer(to: &bitmask, {
+            grammar_matcher_fill_next_token_bitmask(grammarMatcher, $0)
+        }) else {
+            return MLXArray.zeros([vocabSize])
+        }
+        
+        let bytes = bufferSize &<< 2
+        let bitmaskData = UnsafeRawBufferPointer(start: bitmask.data, count: bytes)
+        let bitmask = MLXArray(bitmaskData, [bytes], type: Int8.self)
+        let mask = bitmap[bitmask].reshaped([bytes * 8])[0..<vocabSize]
+        return mask
+    }
+    
+    func advance(token: MLXArray) {
+        let tokenID = token.item(Int32.self)
+        let accepted = grammar_matcher_accept_token(grammarMatcher, tokenID)
+        if !accepted {
+            reset()
+        }
+    }
+    
+    func reset() {
+        grammar_matcher_reset(grammarMatcher)
+    }
+
+    func isTerminated() -> Bool {
+        return grammar_matcher_is_terminated(grammarMatcher)
+    }
+}
+
+private extension DLTensor {
+    static func nextTokenBitmask(bufferSize: Int) -> DLTensor {
+        let dataBytes = bufferSize * MemoryLayout<Int32>.stride
+        let data = UnsafeMutableRawPointer.allocate(byteCount: dataBytes, alignment: 64)
+        data.bindMemory(to: Int32.self, capacity: bufferSize).initialize(repeating: 0, count: bufferSize)
+        
+        let shape = UnsafeMutablePointer<Int64>.allocate(capacity: 1)
+        shape.initialize(repeating: 0, count: 1)
+        shape[0] = Int64(bufferSize)
+        
+        let device = DLDevice(deviceType: 1, deviceId: 0)
+        let dtype = DLDataType(rawCode: 0, bits: 32, lanes: 1)
+        
+        return DLTensor(
+            data: data,
+            device: device,
+            ndim: 1,
+            dtype: dtype,
+            shape: shape,
+            strides: nil,
+            byteOffset: 0
+        )
+    }
+}

--- a/Sources/MLXStructured/Generate.swift
+++ b/Sources/MLXStructured/Generate.swift
@@ -1,0 +1,102 @@
+//
+//  Generate.swift
+//  MLXStructured
+//
+//  Created by Ivan Petrukha on 27.09.2025.
+//
+
+import Foundation
+import JSONSchema
+import MLXLMCommon
+import MLX
+
+#if canImport(FoundationModels)
+import FoundationModels
+#endif
+
+public func generate(
+    input: LMInput,
+    parameters: GenerateParameters = GenerateParameters(),
+    context: ModelContext,
+    grammar: Grammar,
+    didGenerate: ([Int]) -> GenerateDisposition = { _ in .more }
+) async throws -> GenerateResult {
+    let sampler = parameters.sampler()
+    let processor = try await GrammarMaskedLogitProcessor.from(configuration: context.configuration, grammar: grammar)
+    let iterator = try TokenIterator(input: input, model: context.model, processor: processor, sampler: sampler)
+    let result = generate(input: input, context: context, iterator: iterator, didGenerate: didGenerate)
+    return result
+}
+
+public func generate<Content: Decodable>(
+    input: LMInput,
+    parameters: GenerateParameters = GenerateParameters(),
+    context: ModelContext,
+    schema: JSONSchema,
+    generating: Content.Type,
+    indent: Int? = nil,
+    didGenerate: ([Int]) -> GenerateDisposition = { _ in .more }
+) async throws -> (GenerateResult, Content) {
+    let grammar = try Grammar.schema(schema, indent: indent)
+    let sampler = parameters.sampler()
+    let processor = try await GrammarMaskedLogitProcessor.from(configuration: context.configuration, grammar: grammar)
+    let iterator = try TokenIterator(input: input, model: context.model, processor: processor, sampler: sampler)
+    let result = generate(input: input, context: context, iterator: iterator, didGenerate: didGenerate)
+    let content = try JSONDecoder().decode(Content.self, from: Data(result.output.utf8))
+    return (result, content)
+}
+
+#if compiler(>=6.2)
+@available(macOS 26.0, iOS 26.0, *)
+public func generate<Content: Generable>(
+    input: LMInput,
+    parameters: GenerateParameters = GenerateParameters(),
+    context: ModelContext,
+    generating: Content.Type,
+    indent: Int? = nil,
+    didGenerate: ([Int]) -> GenerateDisposition = { _ in .more }
+) async throws -> (GenerateResult, Content) {
+    let sampler = parameters.sampler()
+    let grammar = try Grammar.generable(Content.self, indent: indent)
+    let processor = try await GrammarMaskedLogitProcessor.from(configuration: context.configuration, grammar: grammar)
+    let iterator = try TokenIterator(input: input, model: context.model, processor: processor, sampler: sampler)
+    let result = generate(input: input, context: context, iterator: iterator, didGenerate: didGenerate)
+    let content = try Content(GeneratedContent(json: result.output))
+    return (result, content)
+}
+
+@available(macOS 26.0, iOS 26.0, *)
+public func generate<Content: Generable>(
+    input: LMInput,
+    parameters: GenerateParameters = GenerateParameters(),
+    context: ModelContext,
+    generating: Content.Type,
+    indent: Int? = nil
+) async throws -> AsyncStream<Content.PartiallyGenerated> {
+    let sampler = parameters.sampler()
+    let grammar = try Grammar.generable(Content.self, indent: indent)
+    let processor = try await GrammarMaskedLogitProcessor.from(configuration: context.configuration, grammar: grammar)
+    let iterator = try TokenIterator(input: input, model: context.model, processor: processor, sampler: sampler)
+    let stream = generate(input: input, context: context, iterator: iterator)
+    return AsyncStream { continuation in
+        
+        let task = Task {
+            var output = ""
+            for await generation in stream {
+                if let chunk = generation.chunk {
+                    output.append(chunk)
+                    let generatedContent = try GeneratedContent(json: output)
+                    let partiallyGenerated = try Content.PartiallyGenerated(generatedContent)
+                    continuation.yield(partiallyGenerated)
+                }
+            }
+            
+            continuation.finish()
+        }
+        
+        continuation.onTermination = { _ in
+            task.cancel()
+        }
+    }
+}
+#endif

--- a/Sources/MLXStructured/Grammar/Grammar+Encoding.swift
+++ b/Sources/MLXStructured/Grammar/Grammar+Encoding.swift
@@ -1,0 +1,49 @@
+//
+//  Grammar+Encoding.swift
+//  MLXStructured
+//
+//  Created by Ivan Petrukha on 05.10.2025.
+//
+
+import Foundation
+import JSONSchema
+
+extension JSONEncoder {
+    
+    static let `default` = JSONEncoder()
+    
+    static let sorted: JSONEncoder = {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys, .prettyPrinted]
+        return encoder
+    }()
+}
+
+extension JSONDecoder {
+    
+    static let `default` = JSONDecoder()
+    
+    static func withPropertiesOrderInfo(_ order: [String]) -> JSONDecoder {
+        let decoder = JSONDecoder()
+        decoder.userInfo[JSONSchema.ObjectSchema.Properties.orderInfoKey] = order
+        return decoder
+    }
+}
+
+extension JSONSchema: @retroactive CustomStringConvertible {
+    public var description: String {
+        do {
+            let data = try JSONEncoder.sorted.encode(self)
+            let string = String(decoding: data, as: UTF8.self).sanitizedSchema
+            return string
+        } catch {
+            return "Invalid JSON Schema"
+        }
+    }
+}
+
+extension String {
+    var sanitizedSchema: String {
+        replacingOccurrences(of: "__[0-9]+__", with: "", options: .regularExpression)
+    }
+}

--- a/Sources/MLXStructured/Grammar/Grammar+Generable.swift
+++ b/Sources/MLXStructured/Grammar/Grammar+Generable.swift
@@ -1,0 +1,37 @@
+//
+//  Grammar+Generable.swift
+//  MLXStructured
+//
+//  Created by Rudrank Riyam on 21.09.2025.
+//
+
+import Foundation
+import JSONSchema
+
+#if canImport(FoundationModels)
+import FoundationModels
+#endif
+
+#if compiler(>=6.2)
+@available(macOS 26.0, iOS 26.0, *)
+public extension Grammar {
+    
+    struct OrderContainer: Codable {
+        
+        let order: [String]
+        
+        enum CodingKeys: String, CodingKey {
+            case order = "x-order"
+        }
+    }
+    
+    static func generable<Content: Generable>(_ type: Content.Type, indent: Int? = nil) throws -> Grammar {
+        let generationSchemaData = try JSONEncoder.default.encode(type.generationSchema)
+        let orderContainer = try JSONDecoder.default.decode(OrderContainer.self, from: generationSchemaData)
+        let schema = try JSONDecoder.withPropertiesOrderInfo(orderContainer.order).decode(JSONSchema.self, from: generationSchemaData)
+        let schemaData = try JSONEncoder.sorted.encode(schema)
+        let string = String(decoding: schemaData, as: UTF8.self).sanitizedSchema
+        return .schema(string, indent: indent)
+    }
+}
+#endif

--- a/Sources/MLXStructured/Grammar/Grammar+Schema.swift
+++ b/Sources/MLXStructured/Grammar/Grammar+Schema.swift
@@ -1,0 +1,17 @@
+//
+//  Grammar+Schema.swift
+//  MLXStructured
+//
+//  Created by Ivan Petrukha on 04.10.2025.
+//
+
+import Foundation
+import JSONSchema
+
+public extension Grammar {
+    static func schema(_ schema: JSONSchema = .object(), indent: Int? = nil) throws -> Grammar {
+        let data = try JSONEncoder.sorted.encode(schema)
+        let string = String(decoding: data, as: UTF8.self).sanitizedSchema
+        return .schema(string, indent: indent)
+    }
+}

--- a/Sources/MLXStructured/Grammar/Grammar+Structural.swift
+++ b/Sources/MLXStructured/Grammar/Grammar+Structural.swift
@@ -1,0 +1,17 @@
+//
+//  Grammar+Structural.swift
+//  MLXStructured
+//
+//  Created by Ivan Petrukha on 27.09.2025.
+//
+
+import Foundation
+
+public extension Grammar {
+    init(@FormatBuilder _ content: () -> Encodable) throws {
+        let tag = StructuralTag(format: content())
+        let data = try JSONEncoder.sorted.encode(tag)
+        let string = String(decoding: data, as: UTF8.self).sanitizedSchema
+        self = Grammar.structural(string)
+    }
+}

--- a/Sources/MLXStructured/Grammar/Grammar.swift
+++ b/Sources/MLXStructured/Grammar/Grammar.swift
@@ -1,0 +1,47 @@
+//
+//  Grammar.swift
+//  MLXStructured
+//
+//  Created by Ivan Petrukha on 16.09.2025.
+//
+
+import Foundation
+import JSONSchema
+
+public enum Grammar {
+    case ebnf(String)
+    case regex(String)
+    case schema(String, indent: Int? = nil)
+    case structural(String)
+}
+
+public extension Grammar {
+    
+    @available(*, deprecated, message: "Prefer constructing prompt manually, this property will be removed in the future versions")
+    var raw: String {
+        switch self {
+        case .ebnf(let ebnf):
+            return ebnf
+        case .regex(let regex):
+            return regex
+        case .schema(let schema, _):
+            return schema
+        case .structural(let tag):
+            return tag
+        }
+    }
+    
+    @available(*, deprecated, message: "Prefer constructing prompt manually, this property will be removed in the future versions")
+    var guidance: String? {
+        switch self {
+        case .ebnf:
+            return nil
+        case .regex(let regex):
+            return "Output is regex constrained: \(regex)"
+        case .schema(let schema, _):
+            return "Output is JSON schema constrained: \(schema)"
+        case .structural:
+            return nil
+        }
+    }
+}

--- a/Sources/MLXStructured/GrammarMaskedLogitProcessor.swift
+++ b/Sources/MLXStructured/GrammarMaskedLogitProcessor.swift
@@ -1,0 +1,30 @@
+//
+//  GrammarMaskedLogitProcessor.swift
+//  MLXStructured
+//
+//  Created by Ivan Petrukha on 14.09.2025.
+//
+
+import MLXLMCommon
+import MLX
+
+public final class GrammarMaskedLogitProcessor: LogitProcessor, @unchecked Sendable {
+    
+    public let grammarMatcher: GrammarMatcher
+    
+    public init(grammarMatcher: GrammarMatcher) {
+        self.grammarMatcher = grammarMatcher
+    }
+    
+    public func prompt(_ prompt: MLXArray) {
+        grammarMatcher.reset()
+    }
+    
+    public func process(logits: MLXArray) -> MLXArray {
+        return logits + grammarMatcher.nextTokenMask()
+    }
+    
+    public func didSample(token: MLXArray) {
+        grammarMatcher.advance(token: token)
+    }
+}

--- a/Sources/MLXStructured/GrammarMatcher.swift
+++ b/Sources/MLXStructured/GrammarMatcher.swift
@@ -1,0 +1,15 @@
+//
+//  GrammarMatcher.swift
+//  MLXStructured
+//
+//  Created by Ivan Petrukha on 16.09.2025.
+//
+
+import MLX
+
+public protocol GrammarMatcher {
+    func nextTokenMask() -> MLXArray // 0 or -infinity
+    func advance(token: MLXArray)
+    func reset()
+    func isTerminated() -> Bool
+}

--- a/Sources/MLXStructured/GrammarMatcherFactory.swift
+++ b/Sources/MLXStructured/GrammarMatcherFactory.swift
@@ -1,0 +1,88 @@
+//
+//  GrammarMatcherFactory.swift
+//  MLXStructured
+//
+//  Created by Ivan Petrukha on 20.09.2025.
+//
+
+import Hub
+import MLXLMCommon
+
+public extension GrammarMaskedLogitProcessor {
+    static func from(
+        hub: HubApi = .shared, // TODO: Request changes in swift-transformers to make the tokenizer vocab (and some other properties) public
+        configuration: ModelConfiguration,
+        grammar: Grammar
+    ) async throws -> GrammarMaskedLogitProcessor {
+        let configurations = switch configuration.id {
+        case let .id(id, revision):
+            LanguageModelConfigurationFromHub(modelName: id, revision: revision, hubApi: hub)
+        case let .directory(directory):
+            LanguageModelConfigurationFromHub(modelFolder: directory, hubApi: hub)
+        }
+
+        let (modelConfig, tokenizerConfig, tokenizerData) = try await (
+            configurations.modelConfig,
+            configurations.tokenizerConfig,
+            configurations.tokenizerData
+        )
+
+        // VLMs (e.g. Qwen3.5) nest vocab_size inside text_config
+        let vocabSize = modelConfig?.vocabSize.integer()
+            ?? modelConfig?.textConfig.vocabSize.integer()
+            ?? 0
+        var vocab = Array(repeating: "", count: vocabSize)
+
+        for (key, value) in tokenizerData.model.vocab.dictionary(or: [:]) {
+            if let index = value.integer() {
+                if index >= vocab.count {
+                    vocab.append(contentsOf: Array(repeating: "", count: index - vocab.count + 1))
+                }
+                vocab[index] = key.string
+            }
+        }
+
+        for value in tokenizerData.addedTokens.array(or: []) {
+            if let index = value.id.integer(), let token = value.content.string() {
+                if index >= vocab.count {
+                    vocab.append(contentsOf: Array(repeating: "", count: index - vocab.count + 1))
+                }
+                vocab[index] = token
+            }
+        }
+
+        let decoders: [Config] = switch tokenizerData.decoder.type.string() {
+        case "Sequence":
+            tokenizerData.decoder.decoders.array(or: [])
+        default:
+            [tokenizerData.decoder]
+        }
+
+        var vocabType: Int32 = 0
+        loop: for decoder in decoders {
+            switch decoder.type.string() {
+            case "ByteFallback":
+                vocabType = 1
+                break loop
+            case "ByteLevel":
+                vocabType = 2
+                break loop
+            default:
+                continue
+            }
+        }
+
+        var stopTokenIds: [Int32] = configuration.extraEOSTokens.compactMap(vocab.firstIndex).map(Int32.init)
+        if let tokenizerConfig, let eosToken = tokenizerConfig.eosToken.string(), let eosTokenId = vocab.firstIndex(of: eosToken) {
+            stopTokenIds.append(Int32(eosTokenId))
+        }
+
+//        print("Vocab size:", vocab.count)
+//        print("Vocab type:", vocabType)
+//        print("Stop tokens Ids:", stopTokenIds)
+//        print("Grammar:", grammar)
+
+        let grammarMatcher = try XGrammar(vocab: vocab, vocabType: vocabType, stopTokenIds: stopTokenIds, grammar: grammar)
+        return GrammarMaskedLogitProcessor(grammarMatcher: grammarMatcher)
+    }
+}

--- a/Sources/MLXStructured/Structural/StructuralTag+Builder.swift
+++ b/Sources/MLXStructured/Structural/StructuralTag+Builder.swift
@@ -1,0 +1,141 @@
+//
+//  StructuralTag+Builder.swift
+//  MLXStructured
+//
+//  Created by Ivan Petrukha on 25.09.2025.
+//
+
+@resultBuilder
+public enum FormatBuilder {
+    
+    public static func buildExpression(_ expression: Encodable) -> Encodable {
+        expression
+    }
+    
+    public static func buildBlock(_ component: Encodable) -> Encodable {
+        component
+    }
+    
+    public static func buildOptional(_ component: Encodable?) -> Encodable {
+        component ?? AnyTextFormat()
+    }
+    
+    public static func buildEither(first component: Encodable) -> Encodable {
+        component
+    }
+    
+    public static func buildEither(second component: Encodable) -> Encodable {
+        component
+    }
+    
+    public static func buildLimitedAvailability(_ component: Encodable) -> Encodable {
+        component
+    }
+}
+
+@resultBuilder
+public enum FormatListBuilder {
+    
+    public static func buildExpression(_ expression: Encodable) -> [Encodable] {
+        [expression]
+    }
+    
+    public static func buildBlock(_ components: [Encodable]...) -> [Encodable] {
+        components.flatMap { $0 }
+    }
+    
+    public static func buildOptional(_ component: [Encodable]?) -> [Encodable] {
+        component ?? []
+    }
+    
+    public static func buildEither(first component: [Encodable]) -> [Encodable] {
+        component
+    }
+    
+    public static func buildEither(second component: [Encodable]) -> [Encodable] {
+        component
+    }
+    
+    public static func buildArray(_ components: [[Encodable]]) -> [Encodable] {
+        components.flatMap { $0 }
+    }
+    
+    public static func buildLimitedAvailability(_ component: [Encodable]) -> [Encodable] {
+        component
+    }
+}
+
+@resultBuilder
+public enum TagListBuilder {
+    
+    public static func buildExpression(_ expression: TagFormat) -> [TagFormat] {
+        [expression]
+    }
+    
+    public static func buildBlock(_ components: [TagFormat]...) -> [TagFormat] {
+        components.flatMap { $0 }
+    }
+    
+    public static func buildOptional(_ component: [TagFormat]?) -> [TagFormat] {
+        component ?? []
+    }
+    
+    public static func buildEither(first component: [TagFormat]) -> [TagFormat] {
+        component
+    }
+    
+    public static func buildEither(second component: [TagFormat]) -> [TagFormat] {
+        component
+    }
+    
+    public static func buildArray(_ components: [[TagFormat]]) -> [TagFormat] {
+        components.flatMap { $0 }
+    }
+    
+    public static func buildLimitedAvailability(_ component: [TagFormat]) -> [TagFormat] {
+        component
+    }
+}
+
+public extension StructuralTag {
+    init(@FormatBuilder _ content: () -> Encodable) {
+        self.init(format: content())
+    }
+}
+
+public extension SequenceFormat {
+    init(@FormatListBuilder _ content: () -> [Encodable]) {
+        self.init(elements: content())
+    }
+}
+
+public extension OrFormat {
+    init(@FormatListBuilder _ content: () -> [Encodable]) {
+        self.init(elements: content())
+    }
+}
+
+public extension TagFormat {
+    init(begin: String, end: String, @FormatBuilder _ content: () -> Encodable) {
+        self.init(begin: begin, content: content(), end: end)
+    }
+}
+
+public extension TriggeredTagsFormat {
+    init(triggers: [String], options: Options = [], @TagListBuilder _ content: () -> [TagFormat]) {
+        self.init(triggers: triggers, tags: content(), options: options)
+    }
+}
+
+
+public extension OrFormat {
+    mutating func appending(_ formats: [Encodable]) -> OrFormat {
+        OrFormat(elements: self.elements + formats)
+    }
+}
+
+public extension SequenceFormat {
+    mutating func appending(_ formats: [Encodable]) -> SequenceFormat {
+        SequenceFormat(elements: self.elements + formats)
+    }
+}

--- a/Sources/MLXStructured/Structural/StructuralTag.swift
+++ b/Sources/MLXStructured/Structural/StructuralTag.swift
@@ -1,0 +1,246 @@
+//
+//  StructuralTag.swift
+//  MLXStructured
+//
+//  Created by Ivan Petrukha on 24.09.2025.
+//
+
+import Foundation
+import JSONSchema
+
+public struct AnyEncodable: Encodable {
+    
+    private let _encode: (Encoder) throws -> Void
+    
+    public init<E: Encodable>(_ value: E) {
+        _encode = value.encode
+    }
+    
+    public func encode(to encoder: Encoder) throws {
+        try _encode(encoder)
+    }
+}
+
+public struct StructuralTag: Encodable {
+    
+    public let format: AnyEncodable
+    
+    public init(format: Encodable) {
+        self.format = AnyEncodable(format)
+    }
+    
+    public func encode(to encoder: any Encoder) throws {
+        var container  = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode("structural_tag", forKey: .type)
+        try container.encode(format, forKey: .format)
+    }
+    
+    enum CodingKeys: CodingKey {
+        case type
+        case format
+    }
+}
+
+public struct SequenceFormat: Encodable {
+    
+    public let elements: [AnyEncodable]
+    
+    public init(elements: [Encodable]) {
+        self.elements = elements.map { AnyEncodable($0) }
+    }
+    
+    public func encode(to encoder: any Encoder) throws {
+        var container  = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode("sequence", forKey: .type)
+        try container.encode(elements, forKey: .elements)
+    }
+    
+    enum CodingKeys: CodingKey {
+        case type
+        case elements
+    }
+}
+
+public struct OrFormat: Encodable {
+    
+    public let elements: [AnyEncodable]
+    
+    public init(elements: [Encodable]) {
+        self.elements = elements.map { AnyEncodable($0) }
+    }
+    
+    public func encode(to encoder: any Encoder) throws {
+        var container  = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode("or", forKey: .type)
+        try container.encode(elements, forKey: .elements)
+    }
+    
+    enum CodingKeys: CodingKey {
+        case type
+        case elements
+    }
+}
+
+public struct AnyTextFormat: Encodable {
+    
+    public init() {}
+    
+    public func encode(to encoder: any Encoder) throws {
+        var container  = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode("any_text", forKey: .type)
+    }
+    
+    enum CodingKeys: CodingKey {
+        case type
+    }
+}
+
+public struct ConstTextFormat: Encodable {
+    
+    public let text: String
+    
+    public init(text: String) {
+        self.text = text
+    }
+    
+    public func encode(to encoder: any Encoder) throws {
+        var container  = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode("const_string", forKey: .type)
+        try container.encode(text, forKey: .text)
+    }
+    
+    enum CodingKeys: String, CodingKey {
+        case type
+        case text = "value"
+    }
+}
+
+public struct GrammarFormat: Encodable {
+    
+    public let grammar: String
+    
+    public init(grammar: String) {
+        self.grammar = grammar
+    }
+    
+    public func encode(to encoder: any Encoder) throws {
+        var container  = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode("grammar", forKey: .type)
+        try container.encode(grammar, forKey: .grammar)
+    }
+    
+    enum CodingKeys: CodingKey {
+        case type
+        case grammar
+    }
+}
+
+public struct RegexFormat: Encodable {
+    
+    public let pattern: String
+    
+    public init(pattern: String) {
+        self.pattern = pattern
+    }
+    
+    public func encode(to encoder: any Encoder) throws {
+        var container  = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode("regex", forKey: .type)
+        try container.encode(pattern, forKey: .pattern)
+    }
+    
+    enum CodingKeys: CodingKey {
+        case type
+        case pattern
+    }
+}
+
+public struct JSONSchemaFormat: Encodable {
+    
+    public let schema: JSONSchema
+    
+    public init(schema: JSONSchema) {
+        self.schema = schema
+    }
+    
+    public func encode(to encoder: any Encoder) throws {
+        var container  = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode("json_schema", forKey: .type)
+        try container.encode(schema, forKey: .schema)
+    }
+    
+    enum CodingKeys: String, CodingKey {
+        case type
+        case schema = "json_schema"
+    }
+}
+
+public struct TriggeredTagsFormat: Encodable {
+    
+    public struct Options: RawRepresentable, OptionSet, Sendable {
+        
+        public let rawValue: Int
+        
+        public init(rawValue: Int) {
+            self.rawValue = rawValue
+        }
+        
+        public static let atLeastOne = Options(rawValue: 1 << 0)
+        public static let stopAfterFirst = Options(rawValue: 1 << 1)
+    }
+    
+    public let triggers: [String]
+    public let tags: [TagFormat]
+    public let options: Options
+    
+    public init(triggers: [String], tags: [TagFormat], options: Options = []) {
+        self.triggers = triggers
+        self.tags = tags
+        self.options = options
+    }
+    
+    public func encode(to encoder: any Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode("triggered_tags", forKey: .type)
+        try container.encode(triggers, forKey: .triggers)
+        try container.encode(tags, forKey: .tags)
+        try container.encode(options.contains(.atLeastOne), forKey: .atLeastOne)
+        try container.encode(options.contains(.stopAfterFirst), forKey: .stopAfterFirst)
+    }
+    
+    enum CodingKeys: String, CodingKey {
+        case type
+        case triggers
+        case tags
+        case atLeastOne = "at_least_one"
+        case stopAfterFirst = "stop_after_first"
+    }
+}
+
+public struct TagFormat: Encodable {
+    
+    public let begin: String
+    public let content: AnyEncodable
+    public let end: String
+    
+    public init(begin: String, content: Encodable, end: String) {
+        self.begin = begin
+        self.content = AnyEncodable(content)
+        self.end = end
+    }
+    
+    public func encode(to encoder: any Encoder) throws {
+        var container  = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode("tag", forKey: .type)
+        try container.encode(begin, forKey: .begin)
+        try container.encode(content, forKey: .content)
+        try container.encode(end, forKey: .end)
+    }
+    
+    enum CodingKeys: CodingKey {
+        case type
+        case begin
+        case content
+        case end
+    }
+}

--- a/Tests/MLXStructuredTests/TestErrorHandler.swift
+++ b/Tests/MLXStructuredTests/TestErrorHandler.swift
@@ -1,0 +1,93 @@
+//
+//  TestErrorHandler.swift
+//  MLXStructured
+//
+//  Created by Ivan Petrukha on 18.09.2025.
+//
+
+import Testing
+@testable import MLXStructured
+
+@Test func testEmptyEBNFGrammar() async throws {
+    #expect(performing: {
+        let grammar = Grammar.ebnf("")
+        let _ = try XGrammar(vocab: ["a", "b", "c"], grammar: grammar)
+    }, throws: { error in
+        switch error {
+        case XGrammarError.emptyGrammar:
+            return true
+        default:
+            return false
+        }
+    })
+}
+
+@Test func testIncorrectEBNFGrammar() async throws {
+    #expect(performing: {
+        let grammar = Grammar.ebnf("*")
+        let _ = try XGrammar(vocab: ["a", "b", "c"], grammar: grammar)
+    }, throws: { error in
+        switch error {
+        case XGrammarError.invalidGrammar(let message):
+            return message.contains("The root rule with name \"root\" is not found")
+        default:
+            return false
+        }
+    })
+}
+
+@Test func testEmptyRegexGrammar() async throws {
+    #expect(performing: {
+        let grammar = Grammar.regex("")
+        let _ = try XGrammar(vocab: ["a", "b", "c"], grammar: grammar)
+    }, throws: { error in
+        switch error {
+        case XGrammarError.emptyGrammar:
+            return true
+        default:
+            return false
+        }
+    })
+}
+
+@Test func testIncorrectRegexGrammar() async throws {
+    #expect(performing: {
+        let grammar = Grammar.regex("*")
+        let _ = try XGrammar(vocab: ["a", "b", "c"], grammar: grammar)
+    }, throws: { error in
+        switch error {
+        case XGrammarError.invalidGrammar(let message):
+            return message.contains("Expect element, but got *")
+        default:
+            return false
+        }
+    })
+}
+
+@Test func testEmptyJSONSchemaGrammar() async throws {
+    #expect(performing: {
+        let grammar = Grammar.schema("")
+        let _ = try XGrammar(vocab: ["a", "b", "c"], grammar: grammar)
+    }, throws: { error in
+        switch error {
+        case XGrammarError.emptyGrammar:
+            return true
+        default:
+            return false
+        }
+    })
+}
+
+@Test func testIncorrectJSONSchemaGrammar() async throws {
+    #expect(performing: {
+        let grammar = Grammar.schema(#"{"type": "foo"}"#)
+        let _ = try XGrammar(vocab: ["a", "b", "c"], grammar: grammar)
+    }, throws: { error in
+        switch error {
+        case XGrammarError.invalidGrammar(let message):
+            return message.contains("Unsupported type \"foo\"")
+        default:
+            return false
+        }
+    })
+}

--- a/Tests/MLXStructuredTests/TestGenerablePerformance.swift
+++ b/Tests/MLXStructuredTests/TestGenerablePerformance.swift
@@ -1,0 +1,72 @@
+//
+//  TestGenerablePerformance.swift
+//  MLXStructured
+//
+//  Created by Rudrank Riyam on 21.09.2025.
+//
+
+import Testing
+@testable import MLXStructured
+import MLXLMCommon
+import MLXLLM
+import MLX
+
+#if canImport(FoundationModels)
+import FoundationModels
+#endif
+
+#if compiler(>=6.2)
+@available(macOS 26.0, iOS 26.0, *)
+@Generable
+private struct PerformanceRecord: Codable {
+    @Guide(description: "Simple string field")
+    let text: String
+
+    @Guide(description: "Simple integer field")
+    let value: Int
+}
+
+@Test func testGenerableLlamaPerformance() async throws {
+    guard #available(macOS 26.0, iOS 26.0, *) else { return }
+
+    let vocab = ["<eos>"] + (0...0xFFFF).compactMap({ UnicodeScalar($0).map(String.init) })
+    let model = LlamaModel(.init(
+        hiddenSize: 128,
+        hiddenLayers: 16,
+        intermediateSize: 512,
+        attentionHeads: 32,
+        rmsNormEps: 1e-5,
+        vocabularySize: vocab.count,
+        kvHeads: 8
+    ))
+
+    let grammar = try Grammar.generable(PerformanceRecord.self)
+    let grammarMatcher = try XGrammar(vocab: vocab, vocabType: 0, stopTokenIds: [0], grammar: grammar)
+    let processor = GrammarMaskedLogitProcessor(grammarMatcher: grammarMatcher)
+    let sampler = ArgMaxSampler()
+    let input = LMInput(tokens: MLXArray([1, 2, 3, 4, 5]))
+    let maxTokens = 512
+
+    let clock = ContinuousClock()
+    for _ in 0..<3 { // Warmup to stabilize results
+        let iterator = try TokenIterator(input: input, model: model, processor: nil, sampler: sampler, maxTokens: maxTokens)
+        let _ = Array(iterator)
+    }
+    
+    let plainIterator = try TokenIterator(input: input, model: model, processor: nil, sampler: sampler, maxTokens: maxTokens)
+    let plainStart = clock.now
+    let _ = Array(plainIterator)
+    let plainDuration = clock.now - plainStart
+
+    let constrainedIterator = try TokenIterator(input: input, model: model, processor: processor, sampler: sampler, maxTokens: maxTokens)
+    let constrainedStart = clock.now
+    let _ = Array(constrainedIterator)
+    let constrainedDuration = clock.now - constrainedStart
+
+    let slowdown = (constrainedDuration / plainDuration) - 1
+    #expect(slowdown < 0.15)  // If it's slower by more than 15%, this indicates something is wrong
+    print("Plain duration: \(plainDuration)")
+    print("Generable constrained duration: \(constrainedDuration)")
+    print("Generable constrained decoding slower by \(slowdown.formatted(.percent))")
+}
+#endif

--- a/Tests/MLXStructuredTests/TestGrammarMatcher.swift
+++ b/Tests/MLXStructuredTests/TestGrammarMatcher.swift
@@ -1,0 +1,135 @@
+//
+//  TestGrammarMatcher.swift
+//  MLXStructured
+//
+//  Created by Ivan Petrukha on 16.09.2025.
+//
+
+import Testing
+@testable import MLXStructured
+import MLX
+
+@Test func testEBNFGrammarMatcher() async throws {
+    let vocab = ["Y", "E", "S", "N", "O"]
+    let grammar = Grammar.ebnf(#"root ::= ("YES" | "NO")"#)
+    let grammarMatcher = try XGrammar(vocab: vocab, stopTokenIds: [], grammar: grammar)
+    
+    let advances: [Int] = "YES".map(String.init).compactMap({ vocab.firstIndex(of: $0) })
+    let expectations: [[Int]] = [
+        [1, 0, 0, 1, 0], // "Y" or "N"
+        [0, 1, 0, 0, 0], // "E"
+        [0, 0, 1, 0, 0], // "S"
+    ]
+    
+    for (expectation, advance) in zip(expectations, advances) {
+        let mask = grammarMatcher.nextTokenMask()
+        let allowed = mask.exp().asArray(Int.self)
+        #expect(allowed == expectation)
+        grammarMatcher.advance(token: MLXArray(advance))
+    }
+}
+
+@Test func testEBNFGrammarMatcherWithEOSToken() async throws {
+    let vocab = ["<eos>", "Y", "E", "S", "N", "O"]
+    let grammar = Grammar.ebnf(#"root ::= ("YES" | "NO")"#)
+    let grammarMatcher = try XGrammar(vocab: vocab, stopTokenIds: [0], grammar: grammar)
+    
+    let advances: [Int] = "YES".map(String.init).compactMap({ vocab.firstIndex(of: $0) }) + [0]
+    let expectations: [[Int]] = [
+        [0, 1, 0, 0, 1, 0], // "Y" or "N"
+        [0, 0, 1, 0, 0, 0], // "E"
+        [0, 0, 0, 1, 0, 0], // "S"
+        [1, 0, 0, 0, 0, 0], // "<eos>"
+    ]
+    
+    for (expectation, advance) in zip(expectations, advances) {
+        let mask = grammarMatcher.nextTokenMask()
+        let allowed = mask.exp().asArray(Int.self)
+        #expect(allowed == expectation)
+        grammarMatcher.advance(token: MLXArray(advance))
+    }
+}
+
+@Test func testRegexEmailGrammarMatcher() async throws {
+    let vocab = ["<eos>", "a", "b", "c", "@", "."]
+    let grammar = Grammar.regex(#"^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}$"#) // Simple email regex
+    let grammarMatcher = try XGrammar(vocab: vocab, stopTokenIds: [0], grammar: grammar)
+    
+    let advances: [Int] = "abc@ab.cc".map(String.init).compactMap({ vocab.firstIndex(of: $0) }) + [0]
+    let expectations: [[Int]] = [
+        [0, 1, 1, 1, 0, 1], // Not "@" nor "<eos>
+        [0, 1, 1, 1, 1, 1], // Not "<eos>"
+        [0, 1, 1, 1, 1, 1], // Not "<eos>"
+        [0, 1, 1, 1, 1, 1], // Not "<eos>"
+        [0, 1, 1, 1, 0, 1], // Not "@" nor "<eos>"
+        [0, 1, 1, 1, 0, 1], // Not "@" nor "<eos>"
+        [0, 1, 1, 1, 0, 1], // Not "@" nor "<eos>"
+        [0, 1, 1, 1, 0, 1], // Not "@" nor "<eos>"
+        [0, 1, 1, 1, 0, 1], // Not "@" nor "<eos>"
+        [1, 1, 1, 1, 0, 1], // Not "@"
+    ]
+    
+    for (expectation, advance) in zip(expectations, advances) {
+        let mask = grammarMatcher.nextTokenMask()
+        let allowed = mask.exp().asArray(Int.self)
+        #expect(allowed == expectation)
+        grammarMatcher.advance(token: MLXArray(advance))
+    }
+}
+
+@Test func testRegexPhoneGrammarMatcher() async throws {
+    let vocab = ["<eos>", "+", "1", "2", "3", "4", "5", "6", "7", "8", "9", "0", " "]
+    let grammar = Grammar.regex(#"^\+[0-9\s]{7,15}$"#) // Simple phone regex
+    let grammarMatcher = try XGrammar(vocab: vocab, stopTokenIds: [0], grammar: grammar)
+    
+    let advances: [Int] = "+1 234 5678".map(String.init).compactMap({ vocab.firstIndex(of: $0) }) + [0]
+    let expectations: [[Int]] = [
+        [0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], // "+"
+        [0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1], // Any decimal but not "+" or "<eos>"
+        [0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1], // Any decimal but not "+" or "<eos>"
+        [0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1], // Any decimal but not "+" or "<eos>"
+        [0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1], // Any decimal but not "+" or "<eos>"
+        [0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1], // Any decimal but not "+" or "<eos>"
+        [0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1], // Any decimal but not "+" or "<eos>"
+        [0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1], // Any decimal but not "+" or "<eos>"
+        [1, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1], // Any decimal but not "+"
+        [1, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1], // Any decimal but not "+"
+        [1, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1], // Any decimal but not "+"
+        [1, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1], // Any decimal but not "+"
+    ]
+    
+    for (expectation, advance) in zip(expectations, advances) {
+        let mask = grammarMatcher.nextTokenMask()
+        let allowed = mask.exp().asArray(Int.self)
+        #expect(allowed == expectation)
+        grammarMatcher.advance(token: MLXArray(advance))
+    }
+}
+
+@Test func testJSONSchemaGrammarMatcher() async throws {
+    let vocab = ["<eos>", "{", "}", ":", " ", "\"", "a", "b"]
+    let grammar = try Grammar.schema(.object(properties: ["a": .string()], required: ["a"]))
+    let grammarMatcher = try XGrammar(vocab: vocab, stopTokenIds: [0], grammar: grammar)
+    
+    let advances: [Int] = #"{"a": "b"}"#.map(String.init).compactMap({ vocab.firstIndex(of: $0) }) + [0]
+    let expectations: [[Int]] = [
+        [0, 1, 0, 0, 0, 0, 0, 0], // "{"
+        [0, 0, 0, 0, 0, 1, 0, 0], // """
+        [0, 0, 0, 0, 0, 0, 1, 0], // "a"
+        [0, 0, 0, 0, 0, 1, 0, 0], // """
+        [0, 0, 0, 1, 0, 0, 0, 0], // ":"
+        [0, 0, 0, 0, 1, 0, 0, 0], // " "
+        [0, 0, 0, 0, 0, 1, 0, 0], // """
+        [0, 1, 1, 1, 1, 1, 1, 1], // Any char except "<eos>"
+        [0, 1, 1, 1, 1, 1, 1, 1], // Any char except "<eos>"
+        [0, 0, 1, 0, 0, 0, 0, 0], // "}"
+        [1, 0, 0, 0, 0, 0, 0, 0], // "<eos>"
+    ]
+    
+    for (expectation, advance) in zip(expectations, advances) {
+        let mask = grammarMatcher.nextTokenMask()
+        let allowed = mask.exp().asArray(Int.self)
+        #expect(allowed == expectation)
+        grammarMatcher.advance(token: MLXArray(advance))
+    }
+}

--- a/Tests/MLXStructuredTests/TestMemoryLeaks.swift
+++ b/Tests/MLXStructuredTests/TestMemoryLeaks.swift
@@ -1,0 +1,23 @@
+//
+//  TestMemoryLeaks.swift
+//  MLXStructured
+//
+//  Created by Ivan Petrukha on 21.09.2025.
+//
+
+import Testing
+import Foundation
+@testable import MLXStructured
+
+// This test never fails, but it is still useful for checking memory in the profiler
+// Memory usage is currently stable and never exceeds 30 MB
+@Test func testMemoryLeaks() async throws {
+    for _ in 0..<100 {
+        try autoreleasepool {
+            let vocab = ["<eos>"] + (0...0xFFFF).compactMap({ UnicodeScalar($0).map(String.init) })
+            let grammar = try Grammar.schema(.object(properties: ["a": .string(), "b": .integer()]))
+            let grammarMatcher = try XGrammar(vocab: vocab, vocabType: 0, stopTokenIds: [0], grammar: grammar)
+            _ = grammarMatcher.nextTokenMask()
+        }
+    }
+}

--- a/Tests/MLXStructuredTests/TestPerformance.swift
+++ b/Tests/MLXStructuredTests/TestPerformance.swift
@@ -1,0 +1,69 @@
+//
+//  TestPerformance.swift
+//  MLXStructured
+//
+//  Created by Ivan Petrukha on 19.09.2025.
+//
+
+import Testing
+@testable import MLXStructured
+import MLXLMCommon
+import MLXLLM
+import MLX
+
+@Test func testLlamaPerformance() async throws {
+    let vocab = ["<eos>"] + (0...0xFFFF).compactMap({ UnicodeScalar($0).map(String.init) })
+    let model = LlamaModel(.init(
+        hiddenSize: 128,
+        hiddenLayers: 16,
+        intermediateSize: 512,
+        attentionHeads: 32,
+        rmsNormEps: 1e-5,
+        vocabularySize: vocab.count,
+        kvHeads: 8
+    ))
+        
+    let grammar = try Grammar.schema(.object(
+        properties: [
+            "a": .string(),
+            "b": .integer()
+        ], required: [
+            "a",
+            "b"
+        ]
+    ))
+    
+    let grammarMatcher = try XGrammar(vocab: vocab, vocabType: 0, stopTokenIds: [0], grammar: grammar)
+    let processor = GrammarMaskedLogitProcessor(grammarMatcher: grammarMatcher)
+    let sampler = ArgMaxSampler()
+    let input = LMInput(tokens: MLXArray([1, 2, 3, 4, 5]))
+    let maxTokens = 512 // Without a stopping criterion, both tests generate up to the maximum number of tokens
+    
+    let clock = ContinuousClock()
+    for _ in 0..<3 { // Warmup to stabilize results
+        let iterator = try TokenIterator(input: input, model: model, processor: nil, sampler: sampler, maxTokens: maxTokens)
+        let _ = Array(iterator)
+    }
+    
+    let plainIterator = try TokenIterator(input: input, model: model, processor: nil, sampler: sampler, maxTokens: maxTokens)
+    let plainStart = clock.now
+    let _ = Array(plainIterator)
+    let plainDuration = clock.now - plainStart
+    
+    let constrainedIterator = try TokenIterator(input: input, model: model, processor: processor, sampler: sampler, maxTokens: maxTokens)
+    let constrainedStart = clock.now
+    let _ = Array(constrainedIterator)
+    let constrainedDuration = clock.now - constrainedStart
+    
+    let slowdown = (constrainedDuration / plainDuration) - 1
+    #expect(slowdown < 0.15) // If it's slower by more than 15%, this indicates something is wrong
+    print("Plain duration: \(plainDuration)")
+    print("Constrained duration: \(constrainedDuration)")
+    print("Constrained decoding slower by \(slowdown.formatted(.percent))")
+}
+
+struct ArgMaxSampler: LogitSampler {
+    func sample(logits: MLXArray) -> MLXArray {
+        argMax(logits, axis: -1)
+    }
+}


### PR DESCRIPTION
## Summary
- Copy CMLXStructured (C/C++ XGrammar wrapper) and MLXStructured (Swift structured generation) from jaylann/mlx-swift-structured
- Add xgrammar as git submodule (with dlpack nested submodule initialized)
- Update Package.swift: new targets, dependencies (swift-transformers, swift-json-schema), fix mlx-swift-lm version to 2.30.0
- Update CI workflow for recursive submodule checkout
- Add MLXStructuredTests test target

## Test plan
- [x] `swift build` compiles successfully
- [ ] `swift test --filter MLXStructuredTests` passes

Closes #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)