### PR TITLE
Add CastModel.cast() with explicit JSONSchema parameter

### DIFF
--- a/Sources/Cast/API/CastModel+Generation.swift
+++ b/Sources/Cast/API/CastModel+Generation.swift
@@ -33,16 +33,23 @@ extension CastModel {
 
         let parameters = config.generateParameters
 
-        let result = try await container.perform { context in
-            let userInput = UserInput(prompt: fullPrompt)
-            let lmInput = try await context.processor.prepare(input: userInput)
+        let result: GenerateResult
+        do {
+            result = try await container.perform { context in
+                let userInput = UserInput(prompt: fullPrompt)
+                let lmInput = try await context.processor.prepare(input: userInput)
 
-            return try await MLXStructured.generate(
-                input: lmInput,
-                parameters: parameters,
-                context: context,
-                grammar: grammar
-            )
+                return try await MLXStructured.generate(
+                    input: lmInput,
+                    parameters: parameters,
+                    context: context,
+                    grammar: grammar
+                )
+            }
+        } catch let error as CastError {
+            throw error
+        } catch {
+            throw CastError.generationFailed(error.localizedDescription)
         }
 
         do {

--- a/Sources/Cast/API/CastModel+Generation.swift
+++ b/Sources/Cast/API/CastModel+Generation.swift
@@ -1,0 +1,57 @@
+import Foundation
+import JSONSchema
+import MLX
+@preconcurrency import MLXLMCommon
+@preconcurrency import MLXStructured
+
+extension CastModel {
+
+    public func cast<T: Decodable>(
+        _ prompt: String,
+        as type: T.Type = T.self,
+        schema: JSONSchema,
+        system: String? = nil,
+        config: CastConfiguration = CastConfiguration()
+    ) async throws -> T {
+        guard let container else {
+            throw CastError.modelNotLoaded
+        }
+
+        let grammar: Grammar
+        do {
+            grammar = try Grammar.schema(schema)
+        } catch {
+            throw CastError.schemaGenerationFailed(error.localizedDescription)
+        }
+
+        let fullPrompt: String
+        if let system {
+            fullPrompt = "\(system)\n\n\(prompt)"
+        } else {
+            fullPrompt = prompt
+        }
+
+        let parameters = config.generateParameters
+
+        let result = try await container.perform { context in
+            let userInput = UserInput(prompt: fullPrompt)
+            let lmInput = try await context.processor.prepare(input: userInput)
+
+            return try await MLXStructured.generate(
+                input: lmInput,
+                parameters: parameters,
+                context: context,
+                grammar: grammar
+            )
+        }
+
+        do {
+            return try JSONDecoder().decode(T.self, from: Data(result.output.utf8))
+        } catch {
+            throw CastError.decodingFailed(
+                rawOutput: result.output,
+                error: error.localizedDescription
+            )
+        }
+    }
+}

--- a/Tests/CastTests/CastModelGenerationTests.swift
+++ b/Tests/CastTests/CastModelGenerationTests.swift
@@ -1,0 +1,9 @@
+import JSONSchema
+import Testing
+@testable import Cast
+
+@Test func testCastThrowsModelNotLoaded() async {
+    // CastModel requires load() which downloads a model.
+    // Verify the error path: calling cast() without a loaded model throws modelNotLoaded.
+    // This requires an internal init or test helper — deferred to integration tests.
+}


### PR DESCRIPTION
## Summary
- Add `cast(_:as:schema:system:config:)` generic method on CastModel
- Flow: validate container → Grammar.schema() → container.perform → MLXStructured.generate() → JSONDecoder
- CastError wrapping at each failure point (modelNotLoaded, schemaGenerationFailed, decodingFailed)
- System prompt support via optional `system:` parameter
- CastConfiguration converts to GenerateParameters

## Test plan
- [x] `swift build` compiles
- [ ] Integration test with model (deferred)

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)