### PR TITLE
Add PromptEngine for auto-constructed prompts

### DIFF
--- a/Sources/Cast/Prompt/PromptEngine.swift
+++ b/Sources/Cast/Prompt/PromptEngine.swift
@@ -1,0 +1,70 @@
+import Foundation
+import JSONSchema
+
+public struct FieldAnnotation: Sendable {
+    public let description: String?
+    public let examples: [String]?
+
+    public init(description: String? = nil, examples: [String]? = nil) {
+        self.description = description
+        self.examples = examples
+    }
+}
+
+public enum PromptEngine {
+
+    public static func buildPrompt(
+        userPrompt: String,
+        schema: JSONSchema,
+        annotations: [String: FieldAnnotation] = [:],
+        system: String? = nil
+    ) -> (system: String, user: String) {
+        let systemPrompt: String
+        if let system {
+            systemPrompt = system
+        } else {
+            systemPrompt = buildDefaultSystem(schema: schema, annotations: annotations)
+        }
+        return (system: systemPrompt, user: userPrompt)
+    }
+
+    private static func buildDefaultSystem(
+        schema: JSONSchema,
+        annotations: [String: FieldAnnotation]
+    ) -> String {
+        var parts: [String] = []
+
+        parts.append("You are a structured data extraction assistant.")
+        parts.append("Respond ONLY with valid JSON matching the following schema.")
+        parts.append("")
+
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys, .prettyPrinted]
+        if let data = try? encoder.encode(schema),
+           let str = String(data: data, encoding: .utf8) {
+            parts.append("JSON Schema:")
+            parts.append("```json")
+            parts.append(str)
+            parts.append("```")
+        }
+
+        let guidance = annotations.sorted(by: { $0.key < $1.key }).compactMap { field, ann -> String? in
+            var items: [String] = []
+            if let d = ann.description { items.append(d) }
+            if let e = ann.examples, !e.isEmpty { items.append("Examples: \(e.joined(separator: ", "))") }
+            guard !items.isEmpty else { return nil }
+            return "- \(field): \(items.joined(separator: ". "))"
+        }
+
+        if !guidance.isEmpty {
+            parts.append("")
+            parts.append("Field guidance:")
+            parts.append(contentsOf: guidance)
+        }
+
+        parts.append("")
+        parts.append("Output valid JSON only. No markdown, no explanation.")
+
+        return parts.joined(separator: "\n")
+    }
+}

--- a/Tests/CastTests/PromptEngineTests.swift
+++ b/Tests/CastTests/PromptEngineTests.swift
@@ -1,0 +1,64 @@
+import Testing
+import JSONSchema
+@testable import Cast
+
+@Suite("PromptEngine")
+struct PromptEngineTests {
+
+    @Test func defaultSystemIncludesSchema() throws {
+        let schema = JSONSchema.object(
+            properties: ["name": .string(), "age": .integer()],
+            required: ["name", "age"]
+        )
+        let result = PromptEngine.buildPrompt(userPrompt: "Extract info", schema: schema)
+
+        #expect(result.system.contains("JSON Schema"))
+        #expect(result.system.contains("name"))
+        #expect(result.system.contains("age"))
+        #expect(result.user == "Extract info")
+    }
+
+    @Test func customSystemOverride() {
+        let schema = JSONSchema.object()
+        let result = PromptEngine.buildPrompt(
+            userPrompt: "test",
+            schema: schema,
+            system: "Custom system prompt."
+        )
+        #expect(result.system == "Custom system prompt.")
+    }
+
+    @Test func descriptionAppearsInGuidance() {
+        let schema = JSONSchema.object(properties: ["title": .string()], required: ["title"])
+        let annotations: [String: FieldAnnotation] = [
+            "title": FieldAnnotation(description: "The movie title exactly as written")
+        ]
+        let result = PromptEngine.buildPrompt(userPrompt: "Extract", schema: schema, annotations: annotations)
+
+        #expect(result.system.contains("The movie title exactly as written"))
+        #expect(result.system.contains("Field guidance"))
+    }
+
+    @Test func examplesAppearInGuidance() {
+        let schema = JSONSchema.object(properties: ["summary": .string()], required: ["summary"])
+        let annotations: [String: FieldAnnotation] = [
+            "summary": FieldAnnotation(examples: ["Great pacing", "Weak third act"])
+        ]
+        let result = PromptEngine.buildPrompt(userPrompt: "Summarize", schema: schema, annotations: annotations)
+
+        #expect(result.system.contains("Great pacing"))
+        #expect(result.system.contains("Weak third act"))
+    }
+
+    @Test func emptyAnnotationsNoGuidance() {
+        let schema = JSONSchema.object(properties: ["x": .string()], required: ["x"])
+        let result = PromptEngine.buildPrompt(userPrompt: "test", schema: schema)
+        #expect(!result.system.contains("Field guidance"))
+    }
+
+    @Test func containsJSONInstruction() {
+        let schema = JSONSchema.object()
+        let result = PromptEngine.buildPrompt(userPrompt: "test", schema: schema)
+        #expect(result.system.contains("valid JSON"))
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `PromptEngine` (enum with static methods) that builds structured system prompts from `JSONSchema` and `FieldAnnotation` metadata
- Supports custom system prompt override, field descriptions, and example values in guidance output
- Adds 6 tests covering schema inclusion, annotation rendering, custom override, and JSON instruction presence

## Test plan
- [x] `swift build` passes (PromptEngine.swift compiles with zero warnings under Swift 6 strict concurrency)
- [ ] `swift test --filter CastTests` — blocked by pre-existing CMLXStructured linker errors (xgrammar undefined symbols), not related to this PR
- [x] All types are `Sendable`-conformant

Closes #16, #20

Generated with [Claude Code](https://claude.com/claude-code)