### PR TITLE
Add CastEnum protocol and property wrappers

### DIFF
--- a/Sources/Cast/API/CastEnum.swift
+++ b/Sources/Cast/API/CastEnum.swift
@@ -1,0 +1,17 @@
+import Foundation
+import JSONSchema
+
+public protocol CastEnum: RawRepresentable, CaseIterable, Codable, Sendable
+    where RawValue: Sendable {}
+
+extension CastEnum where RawValue == String {
+    public static var jsonSchema: JSONSchema {
+        .enum(values: allCases.map { .string($0.rawValue) })
+    }
+}
+
+extension CastEnum where RawValue == Int {
+    public static var jsonSchema: JSONSchema {
+        .enum(values: allCases.map { .integer($0.rawValue) })
+    }
+}

--- a/Sources/Cast/API/PropertyWrappers.swift
+++ b/Sources/Cast/API/PropertyWrappers.swift
@@ -1,0 +1,91 @@
+import Foundation
+
+@propertyWrapper
+public struct MaxLength<Value: Sendable>: Sendable {
+    public var wrappedValue: Value
+    public let maxLength: Int
+
+    public init(wrappedValue: Value, _ maxLength: Int) {
+        self.wrappedValue = wrappedValue
+        self.maxLength = maxLength
+    }
+}
+
+@propertyWrapper
+public struct MinLength<Value: Sendable>: Sendable {
+    public var wrappedValue: Value
+    public let minLength: Int
+
+    public init(wrappedValue: Value, _ minLength: Int) {
+        self.wrappedValue = wrappedValue
+        self.minLength = minLength
+    }
+}
+
+@propertyWrapper
+public struct CastRange<Value: Sendable, Bound: Comparable & Sendable>: Sendable {
+    public var wrappedValue: Value
+    public let lowerBound: Bound
+    public let upperBound: Bound
+
+    public init(wrappedValue: Value, _ range: ClosedRange<Bound>) {
+        self.wrappedValue = wrappedValue
+        self.lowerBound = range.lowerBound
+        self.upperBound = range.upperBound
+    }
+}
+
+@propertyWrapper
+public struct MaxCount<Value: Sendable>: Sendable {
+    public var wrappedValue: Value
+    public let maxCount: Int
+
+    public init(wrappedValue: Value, _ maxCount: Int) {
+        self.wrappedValue = wrappedValue
+        self.maxCount = maxCount
+    }
+}
+
+@propertyWrapper
+public struct MinCount<Value: Sendable>: Sendable {
+    public var wrappedValue: Value
+    public let minCount: Int
+
+    public init(wrappedValue: Value, _ minCount: Int) {
+        self.wrappedValue = wrappedValue
+        self.minCount = minCount
+    }
+}
+
+@propertyWrapper
+public struct OneOf<Value: Sendable>: Sendable {
+    public var wrappedValue: Value
+    public let values: [String]
+
+    public init(wrappedValue: Value, _ values: [String]) {
+        self.wrappedValue = wrappedValue
+        self.values = values
+    }
+}
+
+@propertyWrapper
+public struct Description<Value: Sendable>: Sendable {
+    public var wrappedValue: Value
+    public let descriptionText: String
+
+    public init(wrappedValue: Value, _ descriptionText: String) {
+        self.wrappedValue = wrappedValue
+        self.descriptionText = descriptionText
+    }
+}
+
+@propertyWrapper
+public struct Examples<Value: Sendable>: Sendable {
+    public var wrappedValue: Value
+    public let examples: [String]
+
+    public init(wrappedValue: Value, _ examples: String...) {
+        self.wrappedValue = wrappedValue
+        self.examples = examples
+    }
+}

--- a/Tests/CastTests/CastEnumTests.swift
+++ b/Tests/CastTests/CastEnumTests.swift
@@ -1,0 +1,52 @@
+import Foundation
+import Testing
+
+@testable import Cast
+
+enum Color: String, CastEnum {
+    case red, green, blue
+}
+
+enum Priority: Int, CastEnum {
+    case low = 0
+    case medium = 1
+    case high = 2
+}
+
+@Suite("CastEnum")
+struct CastEnumTests {
+
+    @Test("String enum generates correct JSON schema")
+    func stringEnumSchema() throws {
+        let schema = Color.jsonSchema
+        let data = try JSONEncoder().encode(schema)
+        let json = try JSONSerialization.jsonObject(with: data) as! [String: Any]
+        let values = json["enum"] as! [String]
+        #expect(Set(values) == Set(["red", "green", "blue"]))
+    }
+
+    @Test("Int enum generates correct JSON schema")
+    func intEnumSchema() throws {
+        let schema = Priority.jsonSchema
+        let data = try JSONEncoder().encode(schema)
+        let json = try JSONSerialization.jsonObject(with: data) as! [String: Any]
+        let values = json["enum"] as! [Int]
+        #expect(Set(values) == Set([0, 1, 2]))
+    }
+
+    @Test("String enum is Codable")
+    func stringEnumCodable() throws {
+        let original = Color.red
+        let data = try JSONEncoder().encode(original)
+        let decoded = try JSONDecoder().decode(Color.self, from: data)
+        #expect(decoded == original)
+    }
+
+    @Test("Int enum is Codable")
+    func intEnumCodable() throws {
+        let original = Priority.high
+        let data = try JSONEncoder().encode(original)
+        let decoded = try JSONDecoder().decode(Priority.self, from: data)
+        #expect(decoded == original)
+    }
+}

--- a/Tests/CastTests/PropertyWrapperTests.swift
+++ b/Tests/CastTests/PropertyWrapperTests.swift
@@ -1,0 +1,119 @@
+import Foundation
+import Testing
+
+@testable import Cast
+
+struct TestStruct {
+    @MaxLength(100) var title: String = ""
+    @MinLength(1) var name: String = ""
+    @CastRange(1...10) var rating: Int = 0
+    @MaxCount(5) var tags: [String] = []
+    @MinCount(1) var items: [String] = []
+    @OneOf(["USD", "EUR"]) var currency: String = ""
+    @Description("A description") var summary: String = ""
+    @Examples("Good", "Bad") var review: String = ""
+}
+
+@Suite("PropertyWrappers")
+struct PropertyWrapperTests {
+
+    let instance = TestStruct()
+
+    // MARK: - Mirror constraint detection
+
+    @Test("MaxLength constraint readable via Mirror")
+    func maxLengthMirror() {
+        let mirror = Mirror(reflecting: instance)
+        let child = mirror.children.first { $0.label == "_title" }!
+        let wrapper = child.value as! MaxLength<String>
+        #expect(wrapper.maxLength == 100)
+    }
+
+    @Test("MinLength constraint readable via Mirror")
+    func minLengthMirror() {
+        let mirror = Mirror(reflecting: instance)
+        let child = mirror.children.first { $0.label == "_name" }!
+        let wrapper = child.value as! MinLength<String>
+        #expect(wrapper.minLength == 1)
+    }
+
+    @Test("CastRange constraint readable via Mirror")
+    func castRangeMirror() {
+        let mirror = Mirror(reflecting: instance)
+        let child = mirror.children.first { $0.label == "_rating" }!
+        let wrapper = child.value as! CastRange<Int, Int>
+        #expect(wrapper.lowerBound == 1)
+        #expect(wrapper.upperBound == 10)
+    }
+
+    @Test("MaxCount constraint readable via Mirror")
+    func maxCountMirror() {
+        let mirror = Mirror(reflecting: instance)
+        let child = mirror.children.first { $0.label == "_tags" }!
+        let wrapper = child.value as! MaxCount<[String]>
+        #expect(wrapper.maxCount == 5)
+    }
+
+    @Test("MinCount constraint readable via Mirror")
+    func minCountMirror() {
+        let mirror = Mirror(reflecting: instance)
+        let child = mirror.children.first { $0.label == "_items" }!
+        let wrapper = child.value as! MinCount<[String]>
+        #expect(wrapper.minCount == 1)
+    }
+
+    @Test("OneOf constraint readable via Mirror")
+    func oneOfMirror() {
+        let mirror = Mirror(reflecting: instance)
+        let child = mirror.children.first { $0.label == "_currency" }!
+        let wrapper = child.value as! OneOf<String>
+        #expect(wrapper.values == ["USD", "EUR"])
+    }
+
+    @Test("Description constraint readable via Mirror")
+    func descriptionMirror() {
+        let mirror = Mirror(reflecting: instance)
+        let child = mirror.children.first { $0.label == "_summary" }!
+        let wrapper = child.value as! Description<String>
+        #expect(wrapper.descriptionText == "A description")
+    }
+
+    @Test("Examples constraint readable via Mirror")
+    func examplesMirror() {
+        let mirror = Mirror(reflecting: instance)
+        let child = mirror.children.first { $0.label == "_review" }!
+        let wrapper = child.value as! Examples<String>
+        #expect(wrapper.examples == ["Good", "Bad"])
+    }
+
+    // MARK: - WrappedValue access
+
+    @Test("wrappedValue read and write")
+    func wrappedValueAccess() {
+        var s = TestStruct()
+
+        s.title = "Hello"
+        #expect(s.title == "Hello")
+
+        s.name = "World"
+        #expect(s.name == "World")
+
+        s.rating = 5
+        #expect(s.rating == 5)
+
+        s.tags = ["a", "b"]
+        #expect(s.tags == ["a", "b"])
+
+        s.items = ["x"]
+        #expect(s.items == ["x"])
+
+        s.currency = "EUR"
+        #expect(s.currency == "EUR")
+
+        s.summary = "Updated"
+        #expect(s.summary == "Updated")
+
+        s.review = "Excellent"
+        #expect(s.review == "Excellent")
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `CastEnum` protocol for type-safe enum JSON schema generation (String and Int raw values) — #8
- Adds 8 constraint property wrappers (`@MaxLength`, `@MinLength`, `@CastRange`, `@MaxCount`, `@MinCount`, `@OneOf`, `@Description`, `@Examples`) — #9, #10, #11, #12, #13
- Adds comprehensive tests for enum schema generation, Codable conformance, Mirror-based constraint detection, and wrappedValue access — #21

## Test plan
- [x] `swift build` passes
- [x] `swift test --filter CastTests` — all 29 tests pass (13 new + 16 existing)
- [x] Mirror-based constraint detection verified for all 8 property wrappers
- [x] String and Int enum schema generation verified via JSON serialization

🤖 Generated with [Claude Code](https://claude.com/claude-code)