### PR TITLE
feat: @Castable macro with diagnostics and tests (#22-#24, #33-#34)

### DIFF
--- a/Sources/Cast/API/Castable.swift
+++ b/Sources/Cast/API/Castable.swift
@@ -1,0 +1,3 @@
+@attached(member, names: named(castSchema), named(init))
+@attached(extension, conformances: Castable, Codable, Sendable)
+public macro Castable() = #externalMacro(module: "CastMacros", type: "CastableMacro")

--- a/Sources/CastMacros/CastMacroPlugin.swift
+++ b/Sources/CastMacros/CastMacroPlugin.swift
@@ -3,5 +3,5 @@ import SwiftSyntaxMacros
 
 @main
 struct CastMacroPlugin: CompilerPlugin {
-    let providingMacros: [Macro.Type] = []
+    let providingMacros: [Macro.Type] = [CastableMacro.self]
 }

--- a/Sources/CastMacros/CastableDiagnostic.swift
+++ b/Sources/CastMacros/CastableDiagnostic.swift
@@ -1,0 +1,16 @@
+import SwiftDiagnostics
+
+enum CastableDiagnostic: String, DiagnosticMessage {
+    case requiresStruct = "@Castable can only be applied to structs"
+    case rangeOnString = "@CastRange cannot be applied to String properties"
+    case lengthOnNumeric = "@MaxLength/@MinLength can only be applied to String properties"
+    case countOnNonArray = "@MaxCount/@MinCount/@Count can only be applied to Array properties"
+    case invertedRange = "@CastRange lower bound must be less than or equal to upper bound"
+    case conflictingLengths = "@MinLength value must be less than or equal to @MaxLength value"
+    case patternOnNonString = "@Pattern can only be applied to String properties"
+    case precisionOnNonFloat = "@Precision can only be applied to Double or Float properties"
+
+    var message: String { rawValue }
+    var diagnosticID: MessageID { MessageID(domain: "CastMacro", id: String(describing: self)) }
+    var severity: DiagnosticSeverity { .error }
+}

--- a/Sources/CastMacros/CastableMacro.swift
+++ b/Sources/CastMacros/CastableMacro.swift
@@ -1,0 +1,396 @@
+import Foundation
+import SwiftSyntax
+import SwiftSyntaxMacros
+import SwiftDiagnostics
+
+public struct CastableMacro {}
+
+// MARK: - MemberMacro
+
+extension CastableMacro: MemberMacro {
+    public static func expansion(
+        of node: AttributeSyntax,
+        providingMembersOf declaration: some DeclGroupSyntax,
+        conformingTo protocols: [TypeSyntax],
+        in context: some MacroExpansionContext
+    ) throws -> [DeclSyntax] {
+        guard let structDecl = declaration.as(StructDeclSyntax.self) else {
+            context.diagnose(Diagnostic(node: node, message: CastableDiagnostic.requiresStruct))
+            return []
+        }
+
+        let properties = collectProperties(from: structDecl)
+        let diagnostics = validateProperties(properties)
+        for (diagnostic, propNode) in diagnostics {
+            context.diagnose(Diagnostic(node: propNode, message: diagnostic))
+        }
+        guard diagnostics.isEmpty else { return [] }
+
+        let schemaDecl = generateSchemaDecl(properties: properties)
+        let initDecl = generateInitDecl(properties: properties)
+
+        return [schemaDecl, initDecl]
+    }
+}
+
+// MARK: - ExtensionMacro
+
+extension CastableMacro: ExtensionMacro {
+    public static func expansion(
+        of node: AttributeSyntax,
+        attachedTo declaration: some DeclGroupSyntax,
+        providingExtensionsOf type: some TypeSyntaxProtocol,
+        conformingTo protocols: [TypeSyntax],
+        in context: some MacroExpansionContext
+    ) throws -> [ExtensionDeclSyntax] {
+        let ext: DeclSyntax = "extension \(type.trimmed): Castable {}"
+        return [ext.cast(ExtensionDeclSyntax.self)]
+    }
+}
+
+// MARK: - Property Collection
+
+private struct PropertyInfo {
+    let name: String
+    let typeName: String
+    let isOptional: Bool
+    let isArray: Bool
+    let arrayElementType: String?
+    let wrappers: [WrapperInfo]
+    let defaultValue: String?
+    let node: Syntax
+}
+
+private struct WrapperInfo {
+    let name: String
+    let arguments: [String]
+    let node: Syntax
+}
+
+private func collectProperties(from structDecl: StructDeclSyntax) -> [PropertyInfo] {
+    var properties: [PropertyInfo] = []
+
+    for member in structDecl.memberBlock.members {
+        guard let varDecl = member.decl.as(VariableDeclSyntax.self),
+              varDecl.bindingSpecifier.tokenKind == .keyword(.var),
+              let binding = varDecl.bindings.first,
+              let pattern = binding.pattern.as(IdentifierPatternSyntax.self),
+              let typeAnnotation = binding.typeAnnotation?.type else { continue }
+
+        let name = pattern.identifier.text
+        let (typeName, isOptional, isArray, arrayElement) = parseType(typeAnnotation)
+        let wrappers = collectWrappers(from: varDecl)
+        let defaultValue = binding.initializer.map { "\($0.value.trimmed)" }
+
+        properties.append(PropertyInfo(
+            name: name,
+            typeName: typeName,
+            isOptional: isOptional,
+            isArray: isArray,
+            arrayElementType: arrayElement,
+            wrappers: wrappers,
+            defaultValue: defaultValue,
+            node: Syntax(varDecl)
+        ))
+    }
+
+    return properties
+}
+
+private func parseType(_ type: TypeSyntax) -> (name: String, isOptional: Bool, isArray: Bool, arrayElement: String?) {
+    if let optional = type.as(OptionalTypeSyntax.self) {
+        let (name, _, isArray, element) = parseType(optional.wrappedType)
+        return (name, true, isArray, element)
+    }
+
+    if let array = type.as(ArrayTypeSyntax.self) {
+        let elementName = "\(array.element.trimmed)"
+        return ("[\(elementName)]", false, true, elementName)
+    }
+
+    if let ident = type.as(IdentifierTypeSyntax.self) {
+        let name = ident.name.text
+        if name == "Array", let generic = ident.genericArgumentClause?.arguments.first {
+            let elementName = "\(generic.argument.trimmed)"
+            return ("[\(elementName)]", false, true, elementName)
+        }
+        if name == "Optional", let generic = ident.genericArgumentClause?.arguments.first {
+            let inner = "\(generic.argument.trimmed)"
+            return (inner, true, false, nil)
+        }
+        return (name, false, false, nil)
+    }
+
+    return ("\(type.trimmed)", false, false, nil)
+}
+
+private func collectWrappers(from varDecl: VariableDeclSyntax) -> [WrapperInfo] {
+    varDecl.attributes.compactMap { attr -> WrapperInfo? in
+        guard let attrSyntax = attr.as(AttributeSyntax.self),
+              let name = attrSyntax.attributeName.as(IdentifierTypeSyntax.self)?.name.text else {
+            return nil
+        }
+
+        let args: [String]
+        if let argList = attrSyntax.arguments?.as(LabeledExprListSyntax.self) {
+            args = argList.map { "\($0.expression.trimmed)" }
+        } else {
+            args = []
+        }
+
+        return WrapperInfo(name: name, arguments: args, node: Syntax(attrSyntax))
+    }
+}
+
+// MARK: - Validation
+
+private let stringTypes: Set<String> = ["String"]
+private let integerTypes: Set<String> = ["Int", "Int8", "Int16", "Int32", "Int64", "UInt", "UInt8", "UInt16", "UInt32", "UInt64"]
+private let floatTypes: Set<String> = ["Double", "Float"]
+private let numericTypes: Set<String> = integerTypes.union(floatTypes)
+private let boolTypes: Set<String> = ["Bool"]
+
+private func validateProperties(_ properties: [PropertyInfo]) -> [(CastableDiagnostic, Syntax)] {
+    var diagnostics: [(CastableDiagnostic, Syntax)] = []
+
+    for prop in properties {
+        var hasMaxLength: (Int, Syntax)?
+        var hasMinLength: (Int, Syntax)?
+
+        for wrapper in prop.wrappers {
+            switch wrapper.name {
+            case "CastRange":
+                if stringTypes.contains(prop.typeName) || boolTypes.contains(prop.typeName) {
+                    diagnostics.append((.rangeOnString, wrapper.node))
+                }
+                if let bounds = parseRangeBounds(wrapper.arguments) {
+                    if bounds.lower > bounds.upper {
+                        diagnostics.append((.invertedRange, wrapper.node))
+                    }
+                }
+
+            case "MaxLength":
+                if numericTypes.contains(prop.typeName) || boolTypes.contains(prop.typeName) {
+                    diagnostics.append((.lengthOnNumeric, wrapper.node))
+                }
+                if let val = wrapper.arguments.first.flatMap({ Int($0) }) {
+                    hasMaxLength = (val, wrapper.node)
+                }
+
+            case "MinLength":
+                if numericTypes.contains(prop.typeName) || boolTypes.contains(prop.typeName) {
+                    diagnostics.append((.lengthOnNumeric, wrapper.node))
+                }
+                if let val = wrapper.arguments.first.flatMap({ Int($0) }) {
+                    hasMinLength = (val, wrapper.node)
+                }
+
+            case "MaxCount", "MinCount", "Count":
+                if !prop.isArray {
+                    diagnostics.append((.countOnNonArray, wrapper.node))
+                }
+
+            case "Pattern":
+                if !stringTypes.contains(prop.typeName) {
+                    diagnostics.append((.patternOnNonString, wrapper.node))
+                }
+
+            case "Precision":
+                if !floatTypes.contains(prop.typeName) {
+                    diagnostics.append((.precisionOnNonFloat, wrapper.node))
+                }
+
+            default:
+                break
+            }
+        }
+
+        if let (minVal, _) = hasMinLength, let (maxVal, node) = hasMaxLength {
+            if minVal > maxVal {
+                diagnostics.append((.conflictingLengths, node))
+            }
+        }
+    }
+
+    return diagnostics
+}
+
+private func parseRangeBounds(_ args: [String]) -> (lower: Double, upper: Double)? {
+    guard let rangeExpr = args.first else { return nil }
+    let parts = rangeExpr.split(separator: ".", maxSplits: .max, omittingEmptySubsequences: true)
+    guard parts.count >= 2 else { return nil }
+    // Parse "L...U" — after splitting on ".", we get [L, "", "", U] for "L...U"
+    // or components like ["1", "", "", "10"] for "1...10"
+    let cleaned = rangeExpr.replacingOccurrences(of: "...", with: "\t")
+    let components = cleaned.split(separator: "\t")
+    guard components.count == 2,
+          let lower = Double(components[0].trimmingCharacters(in: .whitespaces)),
+          let upper = Double(components[1].trimmingCharacters(in: .whitespaces)) else {
+        return nil
+    }
+    return (lower, upper)
+}
+
+// MARK: - Schema Generation
+
+private func generateSchemaDecl(properties: [PropertyInfo]) -> DeclSyntax {
+    var propertyEntries: [String] = []
+    var requiredFields: [String] = []
+
+    for prop in properties {
+        let schemaExpr = schemaExpression(for: prop)
+        propertyEntries.append("(\"\(prop.name)\", \(schemaExpr))")
+
+        let isNullable = prop.wrappers.contains { $0.name == "Nullable" }
+        if !prop.isOptional && !isNullable {
+            requiredFields.append("\"\(prop.name)\"")
+        }
+    }
+
+    let propertiesStr = propertyEntries.joined(separator: ",\n            ")
+    let requiredStr = requiredFields.isEmpty ? "nil" : "[\(requiredFields.joined(separator: ", "))]"
+
+    return """
+    static let castSchema: JSONSchema = .object(
+        properties: OrderedDictionary(dictionaryLiteral:
+            \(raw: propertiesStr)
+        ),
+        required: \(raw: requiredStr),
+        additionalProperties: .boolean(false)
+    )
+    """
+}
+
+private func generateInitDecl(properties: [PropertyInfo]) -> DeclSyntax {
+    return """
+    init() {
+    }
+    """
+}
+
+private func schemaExpression(for prop: PropertyInfo) -> String {
+    let baseType = prop.typeName
+    var descriptionArg: String?
+    var constraints = SchemaConstraints()
+
+    for wrapper in prop.wrappers {
+        switch wrapper.name {
+        case "MaxLength":
+            constraints.maxLength = wrapper.arguments.first
+        case "MinLength":
+            constraints.minLength = wrapper.arguments.first
+        case "CastRange":
+            if let bounds = wrapper.arguments.first {
+                let cleaned = bounds.replacingOccurrences(of: "...", with: "\t")
+                let parts = cleaned.split(separator: "\t")
+                if parts.count == 2 {
+                    constraints.rangeLower = String(parts[0]).trimmingCharacters(in: .whitespaces)
+                    constraints.rangeUpper = String(parts[1]).trimmingCharacters(in: .whitespaces)
+                }
+            }
+        case "MaxCount":
+            constraints.maxItems = wrapper.arguments.first
+        case "MinCount":
+            constraints.minItems = wrapper.arguments.first
+        case "Count":
+            if let n = wrapper.arguments.first {
+                constraints.minItems = n
+                constraints.maxItems = n
+            }
+        case "OneOf":
+            constraints.oneOfValues = wrapper.arguments.first
+        case "Pattern":
+            constraints.pattern = wrapper.arguments.first
+        case "Precision":
+            if let n = wrapper.arguments.first, let intVal = Int(n) {
+                let multipleOf = pow(10.0, -Double(intVal))
+                constraints.multipleOf = "\(multipleOf)"
+            }
+        case "Description":
+            descriptionArg = wrapper.arguments.first
+        case "Examples", "Nullable", "DefaultValue":
+            break
+        default:
+            break
+        }
+    }
+
+    if let oneOf = constraints.oneOfValues {
+        let descPart = descriptionArg.map { "description: \($0), " } ?? ""
+        return ".enum(\(descPart)values: \(oneOf).map { .string($0) })"
+    }
+
+    if prop.isArray {
+        let elementSchema = elementSchemaExpression(prop.arrayElementType ?? "String")
+        let descPart = descriptionArg.map { "description: \($0), " } ?? ""
+        let itemsPart = "items: \(elementSchema)"
+        var extras: [String] = []
+        if let v = constraints.minItems { extras.append("minItems: \(v)") }
+        if let v = constraints.maxItems { extras.append("maxItems: \(v)") }
+        let extraStr = extras.isEmpty ? "" : ", \(extras.joined(separator: ", "))"
+        return ".array(\(descPart)\(itemsPart)\(extraStr))"
+    }
+
+    if stringTypes.contains(baseType) {
+        return stringSchema(desc: descriptionArg, constraints: constraints)
+    }
+    if integerTypes.contains(baseType) {
+        return integerSchema(desc: descriptionArg, constraints: constraints)
+    }
+    if floatTypes.contains(baseType) {
+        return numberSchema(desc: descriptionArg, constraints: constraints)
+    }
+    if boolTypes.contains(baseType) {
+        let descPart = descriptionArg.map { "description: \($0)" } ?? ""
+        return ".boolean(\(descPart))"
+    }
+
+    // Nested @Castable type — reference its castSchema
+    return "\(baseType).castSchema"
+}
+
+private struct SchemaConstraints {
+    var maxLength: String?
+    var minLength: String?
+    var rangeLower: String?
+    var rangeUpper: String?
+    var maxItems: String?
+    var minItems: String?
+    var oneOfValues: String?
+    var pattern: String?
+    var multipleOf: String?
+}
+
+private func stringSchema(desc: String?, constraints: SchemaConstraints) -> String {
+    var args: [String] = []
+    if let d = desc { args.append("description: \(d)") }
+    if let v = constraints.minLength { args.append("minLength: \(v)") }
+    if let v = constraints.maxLength { args.append("maxLength: \(v)") }
+    if let v = constraints.pattern { args.append("pattern: \(v)") }
+    return ".string(\(args.joined(separator: ", ")))"
+}
+
+private func integerSchema(desc: String?, constraints: SchemaConstraints) -> String {
+    var args: [String] = []
+    if let d = desc { args.append("description: \(d)") }
+    if let v = constraints.rangeLower { args.append("minimum: \(v)") }
+    if let v = constraints.rangeUpper { args.append("maximum: \(v)") }
+    return ".integer(\(args.joined(separator: ", ")))"
+}
+
+private func numberSchema(desc: String?, constraints: SchemaConstraints) -> String {
+    var args: [String] = []
+    if let d = desc { args.append("description: \(d)") }
+    if let v = constraints.multipleOf { args.append("multipleOf: \(v)") }
+    if let v = constraints.rangeLower { args.append("minimum: \(v)") }
+    if let v = constraints.rangeUpper { args.append("maximum: \(v)") }
+    return ".number(\(args.joined(separator: ", ")))"
+}
+
+private func elementSchemaExpression(_ typeName: String) -> String {
+    if stringTypes.contains(typeName) { return ".string()" }
+    if integerTypes.contains(typeName) { return ".integer()" }
+    if floatTypes.contains(typeName) { return ".number()" }
+    if boolTypes.contains(typeName) { return ".boolean()" }
+    return "\(typeName).castSchema"
+}

--- a/Tests/CastMacroTests/CastDiagnosticTests.swift
+++ b/Tests/CastMacroTests/CastDiagnosticTests.swift
@@ -1,0 +1,172 @@
+import SwiftSyntaxMacrosTestSupport
+import Testing
+
+@testable import CastMacros
+
+@Suite("CastableMacro Diagnostics")
+struct CastDiagnosticTests {
+
+    @Test("@Castable on class emits requiresStruct")
+    func requiresStruct() {
+        assertMacroExpansion(
+            """
+            @Castable
+            class Bad {}
+            """,
+            expandedSource: """
+            class Bad {}
+            """,
+            diagnostics: [
+                DiagnosticSpec(message: CastableDiagnostic.requiresStruct.message, line: 1, column: 1),
+            ],
+            macros: testMacros
+        )
+    }
+
+    @Test("@CastRange on String emits rangeOnString")
+    func rangeOnString() {
+        assertMacroExpansion(
+            """
+            @Castable
+            struct Bad {
+                @CastRange(1...10) var name: String = ""
+            }
+            """,
+            expandedSource: """
+            struct Bad {
+                @CastRange(1...10) var name: String = ""
+            }
+            """,
+            diagnostics: [
+                DiagnosticSpec(message: CastableDiagnostic.rangeOnString.message, line: 3, column: 5),
+            ],
+            macros: testMacros
+        )
+    }
+
+    @Test("@MaxLength on Int emits lengthOnNumeric")
+    func lengthOnNumeric() {
+        assertMacroExpansion(
+            """
+            @Castable
+            struct Bad {
+                @MaxLength(10) var count: Int = 0
+            }
+            """,
+            expandedSource: """
+            struct Bad {
+                @MaxLength(10) var count: Int = 0
+            }
+            """,
+            diagnostics: [
+                DiagnosticSpec(message: CastableDiagnostic.lengthOnNumeric.message, line: 3, column: 5),
+            ],
+            macros: testMacros
+        )
+    }
+
+    @Test("@MaxCount on non-Array emits countOnNonArray")
+    func countOnNonArray() {
+        assertMacroExpansion(
+            """
+            @Castable
+            struct Bad {
+                @MaxCount(5) var name: String = ""
+            }
+            """,
+            expandedSource: """
+            struct Bad {
+                @MaxCount(5) var name: String = ""
+            }
+            """,
+            diagnostics: [
+                DiagnosticSpec(message: CastableDiagnostic.countOnNonArray.message, line: 3, column: 5),
+            ],
+            macros: testMacros
+        )
+    }
+
+    @Test("@CastRange(10...5) emits invertedRange")
+    func invertedRange() {
+        assertMacroExpansion(
+            """
+            @Castable
+            struct Bad {
+                @CastRange(10...5) var rating: Int = 0
+            }
+            """,
+            expandedSource: """
+            struct Bad {
+                @CastRange(10...5) var rating: Int = 0
+            }
+            """,
+            diagnostics: [
+                DiagnosticSpec(message: CastableDiagnostic.invertedRange.message, line: 3, column: 5),
+            ],
+            macros: testMacros
+        )
+    }
+
+    @Test("@MinLength(100) @MaxLength(50) emits conflictingLengths")
+    func conflictingLengths() {
+        assertMacroExpansion(
+            """
+            @Castable
+            struct Bad {
+                @MinLength(100) @MaxLength(50) var name: String = ""
+            }
+            """,
+            expandedSource: """
+            struct Bad {
+                @MinLength(100) @MaxLength(50) var name: String = ""
+            }
+            """,
+            diagnostics: [
+                DiagnosticSpec(message: CastableDiagnostic.conflictingLengths.message, line: 3, column: 21),
+            ],
+            macros: testMacros
+        )
+    }
+
+    @Test("@Pattern on Int emits patternOnNonString")
+    func patternOnNonString() {
+        assertMacroExpansion(
+            """
+            @Castable
+            struct Bad {
+                @Pattern("[0-9]+") var count: Int = 0
+            }
+            """,
+            expandedSource: """
+            struct Bad {
+                @Pattern("[0-9]+") var count: Int = 0
+            }
+            """,
+            diagnostics: [
+                DiagnosticSpec(message: CastableDiagnostic.patternOnNonString.message, line: 3, column: 5),
+            ],
+            macros: testMacros
+        )
+    }
+
+    @Test("@Precision on String emits precisionOnNonFloat")
+    func precisionOnNonFloat() {
+        assertMacroExpansion(
+            """
+            @Castable
+            struct Bad {
+                @Precision(2) var name: String = ""
+            }
+            """,
+            expandedSource: """
+            struct Bad {
+                @Precision(2) var name: String = ""
+            }
+            """,
+            diagnostics: [
+                DiagnosticSpec(message: CastableDiagnostic.precisionOnNonFloat.message, line: 3, column: 5),
+            ],
+            macros: testMacros
+        )
+    }
+}

--- a/Tests/CastMacroTests/CastMacroTests.swift
+++ b/Tests/CastMacroTests/CastMacroTests.swift
@@ -1,13 +1,296 @@
+import SwiftSyntaxMacros
 import SwiftSyntaxMacrosTestSupport
 import Testing
 
 @testable import CastMacros
 
-@Suite("CastMacros")
-struct CastMacroTests {
-    @Test("plugin registers no macros initially")
-    func pluginEmpty() {
+let testMacros: [String: any Macro.Type] = [
+    "Castable": CastableMacro.self,
+]
+
+@Suite("CastableMacro Expansion")
+struct CastMacroExpansionTests {
+
+    @Test("simple struct with primitives")
+    func simpleStruct() {
+        assertMacroExpansion(
+            """
+            @Castable
+            struct Review {
+                var title: String = ""
+                var rating: Int = 0
+                var score: Double = 0.0
+                var active: Bool = false
+            }
+            """,
+            expandedSource: """
+            struct Review {
+                var title: String = ""
+                var rating: Int = 0
+                var score: Double = 0.0
+                var active: Bool = false
+
+                static let castSchema: JSONSchema = .object(
+                    properties: OrderedDictionary(dictionaryLiteral:
+                        ("title", .string()),
+                        ("rating", .integer()),
+                        ("score", .number()),
+                        ("active", .boolean())
+                    ),
+                    required: ["title", "rating", "score", "active"],
+                    additionalProperties: .boolean(false)
+                )
+
+                init() {
+                }
+            }
+
+            extension Review: Castable {
+            }
+            """,
+            macros: testMacros
+        )
+    }
+
+    @Test("struct with MaxLength and MinLength")
+    func stringConstraints() {
+        assertMacroExpansion(
+            """
+            @Castable
+            struct Profile {
+                @MaxLength(100) var name: String = ""
+                @MinLength(1) var bio: String = ""
+            }
+            """,
+            expandedSource: """
+            struct Profile {
+                @MaxLength(100) var name: String = ""
+                @MinLength(1) var bio: String = ""
+
+                static let castSchema: JSONSchema = .object(
+                    properties: OrderedDictionary(dictionaryLiteral:
+                        ("name", .string(maxLength: 100)),
+                        ("bio", .string(minLength: 1))
+                    ),
+                    required: ["name", "bio"],
+                    additionalProperties: .boolean(false)
+                )
+
+                init() {
+                }
+            }
+
+            extension Profile: Castable {
+            }
+            """,
+            macros: testMacros
+        )
+    }
+
+    @Test("struct with CastRange")
+    func rangeConstraint() {
+        assertMacroExpansion(
+            """
+            @Castable
+            struct Rated {
+                @CastRange(1...10) var rating: Int = 0
+            }
+            """,
+            expandedSource: """
+            struct Rated {
+                @CastRange(1...10) var rating: Int = 0
+
+                static let castSchema: JSONSchema = .object(
+                    properties: OrderedDictionary(dictionaryLiteral:
+                        ("rating", .integer(minimum: 1, maximum: 10))
+                    ),
+                    required: ["rating"],
+                    additionalProperties: .boolean(false)
+                )
+
+                init() {
+                }
+            }
+
+            extension Rated: Castable {
+            }
+            """,
+            macros: testMacros
+        )
+    }
+
+    @Test("struct with array constraints")
+    func arrayConstraints() {
+        assertMacroExpansion(
+            """
+            @Castable
+            struct Lists {
+                @MaxCount(5) var tags: [String] = []
+                @MinCount(1) var items: [Int] = []
+            }
+            """,
+            expandedSource: """
+            struct Lists {
+                @MaxCount(5) var tags: [String] = []
+                @MinCount(1) var items: [Int] = []
+
+                static let castSchema: JSONSchema = .object(
+                    properties: OrderedDictionary(dictionaryLiteral:
+                        ("tags", .array(items: .string(), maxItems: 5)),
+                        ("items", .array(items: .integer(), minItems: 1))
+                    ),
+                    required: ["tags", "items"],
+                    additionalProperties: .boolean(false)
+                )
+
+                init() {
+                }
+            }
+
+            extension Lists: Castable {
+            }
+            """,
+            macros: testMacros
+        )
+    }
+
+    @Test("struct with optional field not in required")
+    func optionalField() {
+        assertMacroExpansion(
+            """
+            @Castable
+            struct Opt {
+                var name: String = ""
+                var nickname: String? = nil
+            }
+            """,
+            expandedSource: """
+            struct Opt {
+                var name: String = ""
+                var nickname: String? = nil
+
+                static let castSchema: JSONSchema = .object(
+                    properties: OrderedDictionary(dictionaryLiteral:
+                        ("name", .string()),
+                        ("nickname", .string())
+                    ),
+                    required: ["name"],
+                    additionalProperties: .boolean(false)
+                )
+
+                init() {
+                }
+            }
+
+            extension Opt: Castable {
+            }
+            """,
+            macros: testMacros
+        )
+    }
+
+    @Test("struct with nested Castable type")
+    func nestedType() {
+        assertMacroExpansion(
+            """
+            @Castable
+            struct Article {
+                var title: String = ""
+                var author: Author = .init()
+            }
+            """,
+            expandedSource: """
+            struct Article {
+                var title: String = ""
+                var author: Author = .init()
+
+                static let castSchema: JSONSchema = .object(
+                    properties: OrderedDictionary(dictionaryLiteral:
+                        ("title", .string()),
+                        ("author", Author.castSchema)
+                    ),
+                    required: ["title", "author"],
+                    additionalProperties: .boolean(false)
+                )
+
+                init() {
+                }
+            }
+
+            extension Article: Castable {
+            }
+            """,
+            macros: testMacros
+        )
+    }
+
+    @Test("struct with array of nested type")
+    func nestedArrayType() {
+        assertMacroExpansion(
+            """
+            @Castable
+            struct Doc {
+                var sections: [Section] = []
+            }
+            """,
+            expandedSource: """
+            struct Doc {
+                var sections: [Section] = []
+
+                static let castSchema: JSONSchema = .object(
+                    properties: OrderedDictionary(dictionaryLiteral:
+                        ("sections", .array(items: Section.castSchema))
+                    ),
+                    required: ["sections"],
+                    additionalProperties: .boolean(false)
+                )
+
+                init() {
+                }
+            }
+
+            extension Doc: Castable {
+            }
+            """,
+            macros: testMacros
+        )
+    }
+
+    @Test("struct with OneOf wrapper")
+    func oneOfWrapper() {
+        assertMacroExpansion(
+            """
+            @Castable
+            struct Currency {
+                @OneOf(["USD", "EUR"]) var code: String = ""
+            }
+            """,
+            expandedSource: """
+            struct Currency {
+                @OneOf(["USD", "EUR"]) var code: String = ""
+
+                static let castSchema: JSONSchema = .object(
+                    properties: OrderedDictionary(dictionaryLiteral:
+                        ("code", .enum(values: ["USD", "EUR"].map { .string($0) }))
+                    ),
+                    required: ["code"],
+                    additionalProperties: .boolean(false)
+                )
+
+                init() {
+                }
+            }
+
+            extension Currency: Castable {
+            }
+            """,
+            macros: testMacros
+        )
+    }
+
+    @Test("plugin registers CastableMacro")
+    func pluginRegistered() {
         let plugin = CastMacroPlugin()
-        #expect(plugin.providingMacros.isEmpty)
+        #expect(plugin.providingMacros.count == 1)
     }
 }


### PR DESCRIPTION
## Summary
- Implement `@Castable` SwiftSyntax member+extension macro generating `static let castSchema` and `init()` (#22)
- Compile-time diagnostics for invalid annotation combinations (#23)
- Nested `@Castable` type support with recursive schema references (#24)
- 9 macro expansion tests (#33) and 8 diagnostic tests (#34)

## Test plan
- [x] `swift test --filter CastMacroTests` — 17 tests pass
- [x] `swift test` — all 75 tests pass (58 existing + 17 new)