### PR TITLE
feat: add Pattern, Precision, Count, Nullable, DefaultValue wrappers (#25-#29)

### DIFF
--- a/Sources/Cast/API/PropertyWrappers.swift
+++ b/Sources/Cast/API/PropertyWrappers.swift
@@ -198,6 +198,126 @@ extension Examples: Decodable where Value: Decodable {
     }
 }
 
+@propertyWrapper
+public struct Pattern<Value: Sendable>: Sendable {
+    public var wrappedValue: Value
+    public let pattern: String
+
+    public init(wrappedValue: Value, _ pattern: String) {
+        self.wrappedValue = wrappedValue
+        self.pattern = pattern
+    }
+}
+
+extension Pattern: Encodable where Value: Encodable {
+    public func encode(to encoder: Encoder) throws {
+        try wrappedValue.encode(to: encoder)
+    }
+}
+
+extension Pattern: Decodable where Value: Decodable {
+    public init(from decoder: Decoder) throws {
+        self.wrappedValue = try Value(from: decoder)
+        self.pattern = ""
+    }
+}
+
+@propertyWrapper
+public struct Precision<Value: Sendable>: Sendable {
+    public var wrappedValue: Value
+    public let precision: Int
+
+    public init(wrappedValue: Value, _ precision: Int) {
+        self.wrappedValue = wrappedValue
+        self.precision = precision
+    }
+}
+
+extension Precision: Encodable where Value: Encodable {
+    public func encode(to encoder: Encoder) throws {
+        try wrappedValue.encode(to: encoder)
+    }
+}
+
+extension Precision: Decodable where Value: Decodable {
+    public init(from decoder: Decoder) throws {
+        self.wrappedValue = try Value(from: decoder)
+        self.precision = 0
+    }
+}
+
+@propertyWrapper
+public struct Count<Value: Sendable>: Sendable {
+    public var wrappedValue: Value
+    public let count: Int
+
+    public init(wrappedValue: Value, _ count: Int) {
+        self.wrappedValue = wrappedValue
+        self.count = count
+    }
+}
+
+extension Count: Encodable where Value: Encodable {
+    public func encode(to encoder: Encoder) throws {
+        try wrappedValue.encode(to: encoder)
+    }
+}
+
+extension Count: Decodable where Value: Decodable {
+    public init(from decoder: Decoder) throws {
+        self.wrappedValue = try Value(from: decoder)
+        self.count = 0
+    }
+}
+
+@propertyWrapper
+public struct Nullable<Value: Sendable>: Sendable {
+    public var wrappedValue: Value
+    public let isNullable: Bool
+
+    public init(wrappedValue: Value) {
+        self.wrappedValue = wrappedValue
+        self.isNullable = true
+    }
+}
+
+extension Nullable: Encodable where Value: Encodable {
+    public func encode(to encoder: Encoder) throws {
+        try wrappedValue.encode(to: encoder)
+    }
+}
+
+extension Nullable: Decodable where Value: Decodable {
+    public init(from decoder: Decoder) throws {
+        self.wrappedValue = try Value(from: decoder)
+        self.isNullable = false
+    }
+}
+
+@propertyWrapper
+public struct DefaultValue<Value: Sendable>: Sendable {
+    public var wrappedValue: Value
+    public let defaultValue: Value
+
+    public init(wrappedValue: Value, _ defaultValue: Value) {
+        self.wrappedValue = wrappedValue
+        self.defaultValue = defaultValue
+    }
+}
+
+extension DefaultValue: Encodable where Value: Encodable {
+    public func encode(to encoder: Encoder) throws {
+        try wrappedValue.encode(to: encoder)
+    }
+}
+
+extension DefaultValue: Decodable where Value: Decodable {
+    public init(from decoder: Decoder) throws {
+        self.wrappedValue = try Value(from: decoder)
+        self.defaultValue = try Value(from: _ZeroDecoder())
+    }
+}
+
 // Minimal decoder that produces zero values for Bound types in CastRange
 struct _ZeroDecoder: Decoder {
     var codingPath: [CodingKey] = []

--- a/Sources/Cast/Schema/SchemaGenerator.swift
+++ b/Sources/Cast/Schema/SchemaGenerator.swift
@@ -33,6 +33,7 @@ public enum SchemaGenerator {
     private struct CacheEntry: Sendable {
         let schema: JSONSchema
         let annotations: [String: FieldAnnotation]
+        let nullableFields: Set<String>
     }
 
     public static func schema(for type: (some Decodable & Sendable).Type) throws -> JSONSchema {
@@ -41,6 +42,10 @@ public enum SchemaGenerator {
 
     public static func annotations(for type: (some Decodable & Sendable).Type) throws -> [String: FieldAnnotation] {
         try cached(type).annotations
+    }
+
+    public static func nullableFields(for type: (some Decodable & Sendable).Type) throws -> Set<String> {
+        try cached(type).nullableFields
     }
 
     // MARK: - Private
@@ -112,6 +117,18 @@ public enum SchemaGenerator {
                     if let vals = prop.value as? [String] {
                         constraints.oneOfValues = vals
                     }
+                case "pattern":
+                    constraints.pattern = prop.value as? String
+                case "precision":
+                    if let p = prop.value as? Int {
+                        constraints.multipleOf = pow(10.0, -Double(p))
+                    }
+                case "count":
+                    constraints.exactCount = prop.value as? Int
+                case "isNullable":
+                    constraints.isNullable = (prop.value as? Bool) ?? false
+                case "defaultValue":
+                    break
                 case "descriptionText":
                     descriptionText = prop.value as? String
                 case "examples":
@@ -132,13 +149,17 @@ public enum SchemaGenerator {
             }
         }
 
+        var nullableFieldNames = Set<String>()
+        for (name, c) in constraintsMap where c.isNullable {
+            nullableFieldNames.insert(name)
+        }
+
         var properties = OrderedDictionary<String, JSONSchema>()
         for field in info.fields {
             let desc = annotationsMap[field.name]?.description
             if let constraints = constraintsMap[field.name] {
                 properties[field.name] = applyConstraints(constraints, kind: field.kind, description: desc)
             } else if let desc {
-                // For object/enum kinds, preserve the original schema (description goes in annotations only)
                 switch field.kind {
                 case .object, .enumeration:
                     properties[field.name] = field.schema
@@ -150,13 +171,14 @@ public enum SchemaGenerator {
             }
         }
 
+        let required = info.required.filter { !nullableFieldNames.contains($0) }
         let schema = JSONSchema.object(
             properties: properties,
-            required: info.required.isEmpty ? nil : info.required,
+            required: required.isEmpty ? nil : required,
             additionalProperties: .boolean(false)
         )
 
-        return CacheEntry(schema: schema, annotations: annotationsMap)
+        return CacheEntry(schema: schema, annotations: annotationsMap, nullableFields: nullableFieldNames)
     }
 
     /// Build a new JSONSchema from constraints, using SchemaKind to determine the type.
@@ -174,14 +196,14 @@ public enum SchemaGenerator {
 
         switch kind {
         case .string:
-            return .string(description: description, minLength: c.minLength, maxLength: c.maxLength)
+            return .string(description: description, minLength: c.minLength, maxLength: c.maxLength, pattern: c.pattern)
         case .integer:
             return .integer(description: description, minimum: c.intMin, maximum: c.intMax)
         case .number:
-            return .number(description: description, minimum: c.doubleMin, maximum: c.doubleMax)
+            return .number(description: description, multipleOf: c.multipleOf, minimum: c.doubleMin, maximum: c.doubleMax)
         case .array(let element):
             let itemSchema = baseSchema(for: element)
-            return .array(description: description, items: itemSchema, minItems: c.minItems, maxItems: c.maxItems)
+            return .array(description: description, items: itemSchema, minItems: c.exactCount ?? c.minItems, maxItems: c.exactCount ?? c.maxItems)
         default:
             if let description {
                 return withDescription(kind, description)
@@ -230,12 +252,18 @@ private struct FieldConstraints {
     var maxItems: Int?
     var minItems: Int?
     var oneOfValues: [String]?
+    var pattern: String?
+    var multipleOf: Double?
+    var exactCount: Int?
+    var isNullable: Bool = false
 
     var hasConstraints: Bool {
         maxLength != nil || minLength != nil ||
         intMin != nil || intMax != nil ||
         doubleMin != nil || doubleMax != nil ||
         maxItems != nil || minItems != nil ||
-        oneOfValues != nil
+        oneOfValues != nil ||
+        pattern != nil || multipleOf != nil ||
+        exactCount != nil || isNullable
     }
 }

--- a/Tests/CastTests/NewWrapperTests.swift
+++ b/Tests/CastTests/NewWrapperTests.swift
@@ -1,0 +1,196 @@
+import Foundation
+import JSONSchema
+import Testing
+
+@testable import Cast
+
+fileprivate struct NewWrappersStruct {
+    @Pattern("[a-z]+") var code: String = ""
+    @Precision(2) var price: Double = 0.0
+    @Count(3) var topPicks: [String] = []
+    @Nullable var nickname: String = ""
+    @DefaultValue("N/A") var company: String = ""
+}
+
+fileprivate struct CastableNewWrappers: Castable {
+    @Pattern("[a-z]+") var code: String = ""
+    @Precision(2) var price: Double = 0.0
+    @Count(3) var picks: [String] = []
+    @Nullable var nick: String = ""
+    @DefaultValue("N/A") var company: String = ""
+    init() {}
+}
+
+@Suite("NewPropertyWrappers")
+struct NewWrapperTests {
+
+    fileprivate let instance = NewWrappersStruct()
+
+    // MARK: - Mirror constraint detection
+
+    @Test("Pattern constraint readable via Mirror")
+    func patternMirror() {
+        let mirror = Mirror(reflecting: instance)
+        let child = mirror.children.first { $0.label == "_code" }!
+        let wrapper = child.value as! Pattern<String>
+        #expect(wrapper.pattern == "[a-z]+")
+    }
+
+    @Test("Precision constraint readable via Mirror")
+    func precisionMirror() {
+        let mirror = Mirror(reflecting: instance)
+        let child = mirror.children.first { $0.label == "_price" }!
+        let wrapper = child.value as! Precision<Double>
+        #expect(wrapper.precision == 2)
+    }
+
+    @Test("Count constraint readable via Mirror")
+    func countMirror() {
+        let mirror = Mirror(reflecting: instance)
+        let child = mirror.children.first { $0.label == "_topPicks" }!
+        let wrapper = child.value as! Count<[String]>
+        #expect(wrapper.count == 3)
+    }
+
+    @Test("Nullable constraint readable via Mirror")
+    func nullableMirror() {
+        let mirror = Mirror(reflecting: instance)
+        let child = mirror.children.first { $0.label == "_nickname" }!
+        let wrapper = child.value as! Nullable<String>
+        #expect(wrapper.isNullable == true)
+    }
+
+    @Test("DefaultValue constraint readable via Mirror")
+    func defaultValueMirror() {
+        let mirror = Mirror(reflecting: instance)
+        let child = mirror.children.first { $0.label == "_company" }!
+        let wrapper = child.value as! DefaultValue<String>
+        #expect(wrapper.defaultValue == "N/A")
+    }
+
+    // MARK: - wrappedValue access
+
+    @Test("wrappedValue read and write for new wrappers")
+    func wrappedValueAccess() {
+        var s = NewWrappersStruct()
+
+        s.code = "abc"
+        #expect(s.code == "abc")
+
+        s.price = 19.99
+        #expect(s.price == 19.99)
+
+        s.topPicks = ["a", "b", "c"]
+        #expect(s.topPicks == ["a", "b", "c"])
+
+        s.nickname = "Jay"
+        #expect(s.nickname == "Jay")
+
+        s.company = "Acme"
+        #expect(s.company == "Acme")
+    }
+
+    // MARK: - Codable round-trip
+
+    @Test("Codable encode/decode round trip")
+    func codableRoundTrip() throws {
+        var original = NewWrappersStruct()
+        original.code = "test"
+        original.price = 42.5
+        original.topPicks = ["x", "y"]
+        original.nickname = "Nick"
+        original.company = "Corp"
+
+        let encoder = JSONEncoder()
+        let data = try encoder.encode(original)
+        let decoder = JSONDecoder()
+        let decoded = try decoder.decode(NewWrappersStruct.self, from: data)
+
+        #expect(decoded.code == "test")
+        #expect(decoded.price == 42.5)
+        #expect(decoded.topPicks == ["x", "y"])
+        #expect(decoded.nickname == "Nick")
+        #expect(decoded.company == "Corp")
+    }
+
+    // MARK: - Schema generation
+
+    @Test("Pattern produces schema with pattern field")
+    func patternSchema() throws {
+        let schema = try SchemaGenerator.schema(for: CastableNewWrappers.self)
+        let prop = try extractProp(from: schema, named: "code")
+        #expect(prop["type"] as? String == "string")
+        #expect(prop["pattern"] as? String == "[a-z]+")
+    }
+
+    @Test("Precision produces schema with multipleOf field")
+    func precisionSchema() throws {
+        let schema = try SchemaGenerator.schema(for: CastableNewWrappers.self)
+        let prop = try extractProp(from: schema, named: "price")
+        #expect(prop["type"] as? String == "number")
+        #expect(prop["multipleOf"] as? Double == 0.01)
+    }
+
+    @Test("Count produces schema with minItems and maxItems")
+    func countSchema() throws {
+        let schema = try SchemaGenerator.schema(for: CastableNewWrappers.self)
+        let prop = try extractProp(from: schema, named: "picks")
+        #expect(prop["type"] as? String == "array")
+        #expect(prop["minItems"] as? Int == 3)
+        #expect(prop["maxItems"] as? Int == 3)
+    }
+
+    @Test("Nullable removes field from required list")
+    func nullableSchema() throws {
+        let schema = try SchemaGenerator.schema(for: CastableNewWrappers.self)
+        let json = try schemaDict(schema)
+        let required = json["required"] as? [String] ?? []
+        #expect(!required.contains("nick"))
+        #expect(required.contains("code"))
+    }
+
+    @Test("nullableFields returns correct set")
+    func nullableFieldsQuery() throws {
+        let fields = try SchemaGenerator.nullableFields(for: CastableNewWrappers.self)
+        #expect(fields.contains("nick"))
+        #expect(!fields.contains("code"))
+    }
+
+    @Test("DefaultValue does not affect schema constraints")
+    func defaultValueSchema() throws {
+        let schema = try SchemaGenerator.schema(for: CastableNewWrappers.self)
+        let prop = try extractProp(from: schema, named: "company")
+        #expect(prop["type"] as? String == "string")
+        #expect(prop["default"] == nil)
+    }
+}
+
+extension NewWrappersStruct: Codable, Sendable {}
+
+// MARK: - Helpers
+
+private func schemaDict(_ schema: JSONSchema) throws -> [String: Any] {
+    let data = try JSONEncoder().encode(schema)
+    let obj = try JSONSerialization.jsonObject(with: data)
+    return obj as? [String: Any] ?? [:]
+}
+
+private func extractProp(from schema: JSONSchema, named name: String) throws -> [String: Any] {
+    let json = try schemaDict(schema)
+    guard let props = json["properties"] as? [String: Any] else {
+        throw ExtractError(message: "No properties in schema")
+    }
+    for (key, value) in props {
+        let cleanKey = key.replacingOccurrences(
+            of: #"__\d+__"#, with: "", options: .regularExpression
+        )
+        if cleanKey == name, let dict = value as? [String: Any] {
+            return dict
+        }
+    }
+    throw ExtractError(message: "Property '\(name)' not found. Keys: \(props.keys)")
+}
+
+private struct ExtractError: Error {
+    let message: String
+}


### PR DESCRIPTION
## Summary
- Add 5 new property wrappers: @Pattern (regex), @Precision (decimal places), @Count (exact array size), @Nullable (optional in schema), @DefaultValue (stored default)
- Update SchemaGenerator with new FieldConstraints fields, mirror detection, and applyConstraints mapping
- Add nullableFields(for:) public API on SchemaGenerator
- 13 new tests covering mirror reflection, Codable round-trip, and JSON Schema generation

## Test plan
- [x] All 58 existing tests pass
- [x] 13 new tests in NewWrapperTests pass (71 total)

Closes #25, #26, #27, #28, #29