### PR TITLE
feat: tokenizer caching, prepare(), classify() (#30-#32)

### DIFF
--- a/Sources/Cast/API/CastModel+Generation.swift
+++ b/Sources/Cast/API/CastModel+Generation.swift
@@ -187,4 +187,50 @@ extension CastModel {
             )
         }
     }
+
+    /// Classify input into a CastEnum value (String raw value).
+    public func classify<T: CastEnum>(
+        _ prompt: String,
+        as type: T.Type = T.self,
+        system: String? = nil,
+        config: CastConfiguration? = nil
+    ) async throws -> T where T.RawValue == String {
+        let schema = T.castSchema
+        let values = T.allCases.map { $0.rawValue }
+
+        let built = PromptEngine.buildClassificationPrompt(
+            userPrompt: prompt,
+            enumValues: values,
+            system: system
+        )
+
+        var classifyConfig = config ?? CastConfiguration()
+        classifyConfig.maxTokens = min(classifyConfig.maxTokens, 10)
+        classifyConfig.temperature = 0.0
+
+        return try await cast(built.user, as: type, schema: schema, system: built.system, config: classifyConfig)
+    }
+
+    /// Classify input into a CastEnum value (Int raw value).
+    public func classify<T: CastEnum>(
+        _ prompt: String,
+        as type: T.Type = T.self,
+        system: String? = nil,
+        config: CastConfiguration? = nil
+    ) async throws -> T where T.RawValue == Int {
+        let schema = T.castSchema
+        let values = T.allCases.map { String($0.rawValue) }
+
+        let built = PromptEngine.buildClassificationPrompt(
+            userPrompt: prompt,
+            enumValues: values,
+            system: system
+        )
+
+        var classifyConfig = config ?? CastConfiguration()
+        classifyConfig.maxTokens = min(classifyConfig.maxTokens, 10)
+        classifyConfig.temperature = 0.0
+
+        return try await cast(built.user, as: type, schema: schema, system: built.system, config: classifyConfig)
+    }
 }

--- a/Sources/Cast/API/CastModel.swift
+++ b/Sources/Cast/API/CastModel.swift
@@ -7,22 +7,30 @@ import os
 public final class CastModel: Sendable {
 
     private let _container: OSAllocatedUnfairLock<ModelContainer?>
+    let _configuration: OSAllocatedUnfairLock<ModelConfiguration?>
+    let grammarCache = GrammarProcessorCache()
 
     public var container: ModelContainer? {
         _container.withLock { $0 }
+    }
+
+    public var configuration: ModelConfiguration? {
+        _configuration.withLock { $0 }
     }
 
     public var isLoaded: Bool {
         container != nil
     }
 
-    private init(container: ModelContainer) {
+    private init(container: ModelContainer, configuration: ModelConfiguration) {
         _container = OSAllocatedUnfairLock(initialState: container)
+        _configuration = OSAllocatedUnfairLock(initialState: configuration)
     }
 
     /// Test-only initializer for creating a CastModel without loading a real model.
     init(_testContainer: ModelContainer? = nil) {
         _container = OSAllocatedUnfairLock(initialState: _testContainer)
+        _configuration = OSAllocatedUnfairLock(initialState: nil)
     }
 
     public static func load(
@@ -35,10 +43,22 @@ public final class CastModel: Sendable {
         ) { prog in
             progress?(prog)
         }
-        return CastModel(container: container)
+        return CastModel(container: container, configuration: configuration)
     }
 
     public func unload() {
         _container.withLock { $0 = nil }
+    }
+
+    public func prepare(_ types: (any (Decodable & Sendable).Type)...) async throws {
+        guard let configuration else {
+            throw CastError.modelNotLoaded
+        }
+
+        for type in types {
+            _ = try SchemaGenerator.schema(for: type)
+        }
+
+        try await grammarCache.warmUp(for: configuration)
     }
 }

--- a/Sources/Cast/API/GrammarProcessorCache.swift
+++ b/Sources/Cast/API/GrammarProcessorCache.swift
@@ -1,0 +1,44 @@
+import Foundation
+import MLXLMCommon
+@preconcurrency import MLXStructured
+
+actor GrammarProcessorCache {
+    private var cache: [String: TokenizerArtifacts] = [:]
+    private var inFlight: [String: Task<TokenizerArtifacts, any Error>] = [:]
+
+    func artifacts(for configuration: ModelConfiguration) async throws -> TokenizerArtifacts {
+        let key = configuration.name
+
+        if let cached = cache[key] {
+            return cached
+        }
+
+        if let existing = inFlight[key] {
+            return try await existing.value
+        }
+
+        let task = Task {
+            try await GrammarMaskedLogitProcessor.loadTokenizerArtifacts(configuration: configuration)
+        }
+        inFlight[key] = task
+
+        do {
+            let result = try await task.value
+            cache[key] = result
+            inFlight.removeValue(forKey: key)
+            return result
+        } catch {
+            inFlight.removeValue(forKey: key)
+            throw error
+        }
+    }
+
+    func warmUp(for configuration: ModelConfiguration) async throws {
+        _ = try await artifacts(for: configuration)
+    }
+
+    func clear() {
+        cache.removeAll()
+        inFlight.removeAll()
+    }
+}

--- a/Sources/Cast/Prompt/PromptEngine.swift
+++ b/Sources/Cast/Prompt/PromptEngine.swift
@@ -57,4 +57,23 @@ public enum PromptEngine {
 
         return parts.joined(separator: "\n")
     }
+
+    public static func buildClassificationPrompt(
+        userPrompt: String,
+        enumValues: [String],
+        system: String? = nil
+    ) -> (system: String, user: String) {
+        let systemPrompt = system ?? buildClassificationSystem(enumValues: enumValues)
+        return (system: systemPrompt, user: userPrompt)
+    }
+
+    private static func buildClassificationSystem(enumValues: [String]) -> String {
+        var parts: [String] = []
+        parts.append("You are a classifier.")
+        parts.append("Classify the input into exactly one of these categories: \(enumValues.joined(separator: ", ")).")
+        parts.append("")
+        parts.append("Respond with ONLY the category name as a JSON string.")
+        parts.append("No explanation, no markdown.")
+        return parts.joined(separator: "\n")
+    }
 }

--- a/Sources/MLXStructured/GrammarMatcherFactory.swift
+++ b/Sources/MLXStructured/GrammarMatcherFactory.swift
@@ -1,19 +1,18 @@
-//
-//  GrammarMatcherFactory.swift
-//  MLXStructured
-//
-//  Created by Ivan Petrukha on 20.09.2025.
-//
-
 import Hub
 import MLXLMCommon
 
+public struct TokenizerArtifacts: Sendable {
+    public let vocab: [String]
+    public let vocabType: Int32
+    public let stopTokenIds: [Int32]
+}
+
 public extension GrammarMaskedLogitProcessor {
-    static func from(
-        hub: HubApi = .shared, // TODO: Request changes in swift-transformers to make the tokenizer vocab (and some other properties) public
-        configuration: ModelConfiguration,
-        grammar: Grammar
-    ) async throws -> GrammarMaskedLogitProcessor {
+
+    static func loadTokenizerArtifacts(
+        hub: HubApi = .shared,
+        configuration: ModelConfiguration
+    ) async throws -> TokenizerArtifacts {
         let configurations = switch configuration.id {
         case let .id(id, revision):
             LanguageModelConfigurationFromHub(modelName: id, revision: revision, hubApi: hub)
@@ -27,7 +26,6 @@ public extension GrammarMaskedLogitProcessor {
             configurations.tokenizerData
         )
 
-        // VLMs (e.g. Qwen3.5) nest vocab_size inside text_config
         let vocabSize = modelConfig?.vocabSize.integer()
             ?? modelConfig?.textConfig.vocabSize.integer()
             ?? 0
@@ -77,12 +75,28 @@ public extension GrammarMaskedLogitProcessor {
             stopTokenIds.append(Int32(eosTokenId))
         }
 
-//        print("Vocab size:", vocab.count)
-//        print("Vocab type:", vocabType)
-//        print("Stop tokens Ids:", stopTokenIds)
-//        print("Grammar:", grammar)
+        return TokenizerArtifacts(vocab: vocab, vocabType: vocabType, stopTokenIds: stopTokenIds)
+    }
 
-        let grammarMatcher = try XGrammar(vocab: vocab, vocabType: vocabType, stopTokenIds: stopTokenIds, grammar: grammar)
+    static func from(
+        artifacts: TokenizerArtifacts,
+        grammar: Grammar
+    ) throws -> GrammarMaskedLogitProcessor {
+        let grammarMatcher = try XGrammar(
+            vocab: artifacts.vocab,
+            vocabType: artifacts.vocabType,
+            stopTokenIds: artifacts.stopTokenIds,
+            grammar: grammar
+        )
         return GrammarMaskedLogitProcessor(grammarMatcher: grammarMatcher)
+    }
+
+    static func from(
+        hub: HubApi = .shared,
+        configuration: ModelConfiguration,
+        grammar: Grammar
+    ) async throws -> GrammarMaskedLogitProcessor {
+        let artifacts = try await loadTokenizerArtifacts(hub: hub, configuration: configuration)
+        return try from(artifacts: artifacts, grammar: grammar)
     }
 }

--- a/Tests/CastTests/CacheTests.swift
+++ b/Tests/CastTests/CacheTests.swift
@@ -1,0 +1,21 @@
+import Testing
+
+@testable import Cast
+
+@Suite("GrammarProcessorCache")
+struct CacheTests {
+
+    @Test("prepare throws modelNotLoaded when no model")
+    func prepareNoModel() async {
+        let model = CastModel(_testContainer: nil)
+        await #expect(throws: CastError.self) {
+            try await model.prepare(String.self)
+        }
+    }
+
+    @Test("cache clears without error")
+    func cacheClear() async {
+        let cache = GrammarProcessorCache()
+        await cache.clear()
+    }
+}

--- a/Tests/CastTests/ClassifyTests.swift
+++ b/Tests/CastTests/ClassifyTests.swift
@@ -1,0 +1,51 @@
+import Testing
+
+@testable import Cast
+
+enum TestSentiment: String, CastEnum {
+    case positive, negative, neutral
+}
+
+@Suite("Classify")
+struct ClassifyTests {
+
+    @Test("classify throws modelNotLoaded when no model")
+    func classifyNoModel() async {
+        let model = CastModel(_testContainer: nil)
+        await #expect(throws: CastError.self) {
+            try await model.classify("test", as: TestSentiment.self)
+        }
+    }
+
+    @Test("classification prompt includes enum values")
+    func classificationPromptValues() {
+        let values = ["positive", "negative", "neutral"]
+        let result = PromptEngine.buildClassificationPrompt(
+            userPrompt: "This is great!",
+            enumValues: values
+        )
+        #expect(result.system.contains("positive"))
+        #expect(result.system.contains("negative"))
+        #expect(result.system.contains("neutral"))
+    }
+
+    @Test("classification uses custom system prompt when provided")
+    func customSystemPrompt() {
+        let custom = "Custom classifier"
+        let result = PromptEngine.buildClassificationPrompt(
+            userPrompt: "test",
+            enumValues: ["a", "b"],
+            system: custom
+        )
+        #expect(result.system == custom)
+    }
+
+    @Test("classification prompt passes user prompt through")
+    func userPromptPassthrough() {
+        let result = PromptEngine.buildClassificationPrompt(
+            userPrompt: "analyze this text",
+            enumValues: ["yes", "no"]
+        )
+        #expect(result.user == "analyze this text")
+    }
+}


### PR DESCRIPTION
## Summary
- Refactor `GrammarMatcherFactory` into two-step `TokenizerArtifacts` loading for caching (#30)
- Add `GrammarProcessorCache` actor with in-flight request dedup (#30)
- Add `CastModel.prepare()` to pre-warm grammar and schema caches (#31)
- Add `CastModel.classify()` with classification-optimized prompt (#32)

## Test plan
- [x] `swift test --filter CastTests` — 64 tests pass (58 existing + 6 new)
- [x] `swift build` — clean build