### PR TITLE
test(ci): skip MLX runtime tests on CI; pin README install to v0.1.0

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,6 +21,7 @@ Detailed rules live in `.claude/rules/`. Key principles:
 - **Parallel Work**: Consider subagents/teams for non-trivial tasks. See `parallel-work.md`.
 - **Apple APIs**: Always verify with AppleDocs + web search before using. See `apple-api-verification.md`.
 - **Macros**: SwiftSyntax patterns, testing macros. See `macro-development.md`.
+- **Release**: Staged workflow — PRs target `stage`, `main` is release-only, semver tags via `release.yml`. See `release-workflow.md`.
 - **ADRs**: Write `docs/decisions/NNNN-*.md` for complex decisions before committing. See `documentation.md`.
 
 ## Pre-Commit Workflow
@@ -107,3 +108,10 @@ docs/
 - `@Castable` consumers need `import Cast` **plus** `import Collections` and `import JSONSchema` — the macro expansion references `JSONSchema` and `OrderedDictionary` directly and the library does not `@_exported`-re-export them.
 - Runnable examples live in `Examples/` (own `Package.swift`, `.package(path: "..")`); each is `Examples/Sources/<Name>/main.swift`, registered as an `executableTarget`. CI is `.github/workflows/examples.yml` — `swift build` only, no auto-run.
 - DocC site lives at `Sources/Cast/Cast.docc/`. Each `Examples/Sources/<Name>/main.swift` is mirrored to a `Cast.docc/Examples/<Name>.md` article via `scripts/generate-example-docs.sh`; CI (`.github/workflows/docs.yml`) regenerates before building, so committed articles can drift but the published site never does. When adding a new example, also add a `<doc:Name>` entry under `## Topics > Examples` in `Cast.docc/Cast.md`.
+- Default branch is `stage`, not `main`. PRs target `stage`. `main` is release-only and updated exclusively by `.github/workflows/release.yml` (workflow_dispatch, semver input, fast-forwards `stage`→`main`, tags `vX.Y.Z`, creates GitHub Release). See `.claude/rules/release-workflow.md`.
+- License is **Apache-2.0 unified** across the package. `LICENSE` (root) + `NOTICE` credits the two vendored upstreams (`petrukha-ivan/mlx-swift-structured` → `Sources/MLXStructured/`, `mlc-ai/xgrammar` submodule → `Sources/CMLXStructured/xgrammar/`). Both upstreams are also Apache-2.0; their LICENSE is preserved in-tree. Don't relicense; don't add GPL/LGPL/AGPL vendored code without explicit decision.
+- `Sources/MLXStructured/LICENSE` must be in the `MLXStructured` target's `exclude:` list in `Package.swift` — SPM otherwise emits an "unhandled file" warning.
+- CI (`macos-15`) cannot run MLX runtime tests — `swift test` exits with `MLX error: Failed to load the default metallib`. Tests that invoke MLX use the `.requiresMetal` Swift Testing trait (in `Tests/CastTests/TestHelpers.swift` and `Tests/MLXStructuredTests/TestHelpers.swift`) which skips when `CI=true`. Macro/schema/property-wrapper/validator/prompt-engine/JSON-repair tests do NOT need this gate. See issue #75.
+- `scripts/pre-public-check.sh` is the safety scanner used before any visibility change, history rewrite, or accepting CI-touching contributions. Exit `0` = safe; `1` = findings.
+- Repo is **public** at `https://github.com/jaylann/Cast`. Standard `macos-15` runners are free with no minute cap on public repos. Never switch workflows to `macos-15-large` / `-xlarge` — those "larger runners" are billed even on public repos.
+- `.claude/` is gitignored (line 41 of `.gitignore`). Files under `.claude/rules/`, `.claude/hooks/`, and `.claude/settings.json` are local-only per-developer config — they don't ship with the repo. CLAUDE.md at the root IS tracked.

--- a/Examples/CLAUDE.md
+++ b/Examples/CLAUDE.md
@@ -1,0 +1,58 @@
+# Examples
+
+Runnable demonstrations of Cast's public API. Each example is a self-contained Swift executable that builds against the parent package.
+
+## Structure
+
+```
+Examples/
+  Package.swift                           # references parent via .package(path: "..")
+  Sources/
+    HelloCast/main.swift                  # one example per directory
+    PropertyWrappersTour/main.swift
+    NestedTypes/main.swift
+    …
+```
+
+`Package.swift` declares each example as an `executableTarget`; building `Examples/` runs `swift build` against all of them simultaneously.
+
+## Adding a new example
+
+1. **Create `Sources/<Name>/main.swift`.** First line *must* be a single-line comment in this exact form:
+   ```swift
+   // What this shows: <one-sentence description>
+   ```
+   This becomes the DocC article description (see "DocC mirroring" below).
+2. **Register the executable** in `Examples/Package.swift` under `targets:`:
+   ```swift
+   .executableTarget(name: "<Name>", dependencies: ["Cast"], path: "Sources/<Name>")
+   ```
+3. **Add a DocC topic entry** in `Sources/Cast/Cast.docc/Cast.md` under `## Topics` → `### Examples`:
+   ```markdown
+   - <doc:<Name>>
+   ```
+4. **Build to verify**: `cd Examples && swift build`. CI will do the same on push to `stage` (path-filtered to `Sources/Cast/**` or `Examples/**`).
+
+The corresponding `Cast.docc/Examples/<Name>.md` article is **auto-generated** — don't write it by hand; the script overwrites it.
+
+## DocC mirroring
+
+`scripts/generate-example-docs.sh` reads each `Examples/Sources/<Name>/main.swift`, takes the first-line `// What this shows:` comment as the article description, and writes `Sources/Cast/Cast.docc/Examples/<Name>.md` with the source rendered as a Swift code block.
+
+CI (`.github/workflows/docs.yml`) regenerates these articles before building DocC, so committed `.md` files can drift from source — but the *published* site never does. If you only edit `main.swift`, run the script locally to see the rendered article; otherwise a stale committed `.md` will look wrong locally but be correct online.
+
+```bash
+./scripts/generate-example-docs.sh
+```
+
+## CI behavior
+
+- `examples.yml` builds (no run) on push to `stage` and on PRs to `stage`, path-filtered to `Sources/Cast/**`, `Examples/**`, and the workflow file itself.
+- `docs.yml` regenerates articles + builds DocC + deploys to GitHub Pages on push to `main`.
+- Examples are never *executed* in CI — they typically need a downloaded LLM model, which is too heavy + slow.
+
+## Don'ts
+
+- Don't depend on `Sources/MLXStructured` directly from an example — the public API surface is `import Cast`. Examples are also documentation; reaching past the public layer would mislead users.
+- Don't commit a generated `Cast.docc/Examples/<Name>.md` divergent from `main.swift` and assume CI will fix it — it does, but local DocC preview won't until you re-run the script.
+- Don't add examples that require interactive input (stdin prompts, file picks, etc.) — they break the "build only, no run" CI assumption and confuse readers.

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Swift Package Manager. Add to your `Package.swift`:
 
 ```swift
 dependencies: [
-    .package(url: "https://github.com/jaylann/Cast.git", branch: "main")
+    .package(url: "https://github.com/jaylann/Cast.git", from: "0.1.0")
 ],
 targets: [
     .target(

--- a/Sources/CastMacros/CLAUDE.md
+++ b/Sources/CastMacros/CLAUDE.md
@@ -1,0 +1,32 @@
+# Sources/CastMacros
+
+Compiler plugin target for the `@Castable` macro. Runs at **build time** inside the Swift compiler — not at runtime.
+
+## Files
+
+- `CastMacroPlugin.swift` — plugin entry point. Registers macros so the compiler can find them. Add new macros to this list.
+- `CastableMacro.swift` — main `@Castable` implementation. Reads the annotated struct's stored properties + their property-wrapper attributes and emits the JSON Schema + grammar skeleton.
+
+## Macro patterns
+
+- Receive a `MacroExpansionContext` and `AttributeSyntax` / `DeclSyntax` node from SwiftSyntax. Walk the AST to extract what you need.
+- Emit code as `DeclSyntax(stringLiteral: ...)` — Swift parses the string back into syntax for you.
+- Diagnose problems with `context.diagnose(...)` rather than throwing or silently failing. Diagnostics show up in Xcode and `swift build` output and let users fix issues at the point of macro use.
+- For `@Castable`: read property wrappers (`@MaxLength`, `@Range`, `@Description`) by walking attribute lists on each `VariableDeclSyntax`. The wrapper drives the schema — wrappers without a matching code-gen path will silently no-op, so add them deliberately.
+
+## Testing macros
+
+Tests live in `Tests/CastMacroTests/`. Use `swift-syntax`'s `assertMacroExpansion` to compare expected vs actual expansion as text. The test framework runs macros in-process, so:
+- Test failures often show as a textual diff — read the diff carefully; subtle whitespace and trailing-comma differences trip people up.
+- If the macro emits diagnostics, the test asserts on those too (file/line/severity/message).
+- Tests run as part of the regular `swift test` and pass on CI (they don't need MLX runtime — pure compile-time work).
+
+## Cross-references
+
+- The grammar that this macro emits is consumed by `Sources/Cast/Schema/` at runtime to build a `GrammarMatcher`.
+- For SwiftSyntax patterns or build-tooling questions, see `.claude/rules/macro-development.md` and `build-tooling.md`.
+
+## Don'ts
+
+- Don't add runtime dependencies here — this target is a compiler plugin and ships *only* at build time. Anything heavy belongs in `Sources/Cast/`.
+- Don't fork SwiftSyntax behavior; if you need a new helper, add it to a small extension here rather than reaching across targets.

--- a/Sources/MLXStructured/CLAUDE.md
+++ b/Sources/MLXStructured/CLAUDE.md
@@ -1,0 +1,33 @@
+# Sources/MLXStructured
+
+Vendored from [petrukha-ivan/mlx-swift-structured](https://github.com/petrukha-ivan/mlx-swift-structured), Apache-2.0. The `LICENSE` file in this directory is the upstream's, kept verbatim for attribution. Cast itself is also Apache-2.0 — same license, no segmentation.
+
+## Don't modify casually
+
+The default stance is **don't touch these files**. The reason this code is vendored (rather than pulled as an SPM dependency) is to keep the binding stable while we shape Cast's public API; we expect to merge upstream changes back in periodically.
+
+If you must modify a file:
+- Leave the existing header intact (`// Created by Ivan Petrukha on …`).
+- Add a one-line marker near the top: `// Modifications: <description> by <author>, <year>`. This is required by Apache-2.0 §4(b) when redistributing modified files.
+- Keep modifications surgical — wider refactors should land upstream first, then sync down.
+
+## Folder map
+
+- `Backends/` — adapters between MLX arrays and the underlying grammar engine. `XGrammar.swift` is the bridge to `Sources/CMLXStructured/`.
+- `Grammar/` — `Grammar`, `Grammar+Schema.swift`, `Grammar+Structural.swift`, `Grammar+Encoding.swift`. Pure-Swift grammar representation independent of the matching engine.
+- `Structural/` — `StructuralTag` and its builder for the structural-output pattern.
+- `GrammarMatcher.swift`, `GrammarMatcherFactory.swift`, `GrammarMaskedLogitProcessor.swift` — the runtime path: factory builds a matcher from a tokenizer + grammar, the processor masks invalid tokens during MLX generation.
+- `Generate.swift` — the entry point that ties matcher + processor + MLX's `generate()` together.
+
+## SPM gotcha
+
+`LICENSE` in this directory must be in the `MLXStructured` target's `exclude:` list in the root `Package.swift`. Otherwise SPM emits "found 1 file(s) which are unhandled". Don't add other unhandled files here without also excluding them.
+
+## Updating from upstream
+
+Rough procedure (no automation today):
+1. Fetch upstream: `git fetch https://github.com/petrukha-ivan/mlx-swift-structured main`.
+2. Diff against local: `git diff FETCH_HEAD -- Sources/MLXStructured/`. Review every change.
+3. Apply only the bits you want, preserving any local `// Modifications:` markers.
+4. Bump the upstream commit SHA in the root `NOTICE` file.
+5. Run `swift test` locally (where Metal works) to verify nothing broke.

--- a/Tests/CLAUDE.md
+++ b/Tests/CLAUDE.md
@@ -1,0 +1,47 @@
+# Tests
+
+All targets use [Swift Testing](https://developer.apple.com/documentation/testing) (`@Test`, `@Suite`, `#expect`), not XCTest. Run with `swift test` (or `swift test --filter <TargetName>` for a focused subset).
+
+## Test targets
+
+- `CastTests/` — main library tests: API shape, schema generation, property wrappers, validators, prompt engine, JSON repair, classification, error types.
+- `CastMacroTests/` — `@Castable` macro expansion tests via `assertMacroExpansion`. Pure compile-time, no runtime dependencies.
+- `MLXStructuredTests/` — vendored test suite for the grammar matcher / structural tag / generation paths. Many of these touch MLX runtime.
+
+## CI vs local: the `.requiresMetal` trait
+
+GitHub-hosted `macos-15` runners can't load `default.metallib`, so any test that triggers MLX runtime crashes the test process. The project defines a Swift Testing trait that **skips** affected tests when `CI=true`:
+
+```swift
+@Test("Llama loads", .requiresMetal)
+func loadsModel() async throws { … }
+```
+
+Definitions live in:
+- `Tests/CastTests/TestHelpers.swift`
+- `Tests/MLXStructuredTests/TestHelpers.swift`
+
+(Each test target needs its own copy; Swift Testing traits aren't transparently shared across targets.)
+
+**Apply `.requiresMetal` only to tests that actually invoke MLX.** Macro tests, schema generation, property-wrapper introspection, validator logic, prompt-template assembly, JSON-repair logic, classification logic, configuration types — none of these need Metal. Tagging them would silently shrink CI coverage. When in doubt: write the test without the trait, run `CI=true swift test`, and only add the trait if it crashes with a metallib error.
+
+Local development on Apple Silicon runs every test (the env var isn't set), so you don't lose coverage when shipping.
+
+## Conventions
+
+- One `@Suite` per concept (`@Suite("Classify")`, `@Suite("PromptEngine")`); flat `@Test` functions inside.
+- Test names read as English sentences: `func stringEnumCastSchemaProviding()` → "String CastEnum conforms to CastSchemaProviding".
+- Performance tests use `@Test` with timing assertions, not `XCTMeasure`. Tagging them `.requiresMetal` is usually correct since they exercise model loading.
+- Async tests use `async throws`; `#expect(throws: ...)` for expected error paths.
+- Helpers (test fixtures, custom traits) live in `TestHelpers.swift` per target — keep one file per target rather than splitting into many.
+
+## Running
+
+```bash
+swift test                          # all tests, locally (Metal available)
+CI=true swift test                  # mimic CI: MLX-runtime tests skip
+swift test --filter CastMacroTests  # macros only
+swift test --filter MLXStructured   # vendored grammar/matcher tests
+```
+
+For test-writing patterns and TDD workflow, see `.claude/agents/swift-test-writer.md` and `.claude/rules/testing.md`.

--- a/Tests/CastTests/GPUSafetyTests.swift
+++ b/Tests/CastTests/GPUSafetyTests.swift
@@ -1,18 +1,18 @@
-import Testing
 @testable import Cast
+import Testing
 
-@Test func testErrorHandlerSetupIsIdempotent() {
+@Test func errorHandlerSetupIsIdempotent() {
     CastModel.ensureErrorHandler()
     CastModel.ensureErrorHandler()
 }
 
-@Test func testCheckAndClearReturnsNilWhenNoError() {
+@Test func checkAndClearReturnsNilWhenNoError() {
     CastModel.ensureErrorHandler()
     let error = CastModel.checkAndClearMLXGlobalError()
     #expect(error == nil)
 }
 
-@Test func testCheckAndClearIsAtomic() {
+@Test func checkAndClearIsAtomic() {
     CastModel.ensureErrorHandler()
     // First read clears any stale state
     _ = CastModel.checkAndClearMLXGlobalError()
@@ -21,7 +21,7 @@ import Testing
     #expect(error == nil)
 }
 
-@Test func testCleanupGPUDoesNotCrash() {
+@Test(.requiresMetal) func cleanupGPUDoesNotCrash() {
     let model = CastModel()
     // cleanupGPU on an unloaded model should not crash (try? swallows errors)
     model.cleanupGPU()

--- a/Tests/CastTests/TestHelpers.swift
+++ b/Tests/CastTests/TestHelpers.swift
@@ -1,0 +1,14 @@
+import Foundation
+import Testing
+
+extension Trait where Self == Testing.ConditionTrait {
+    /// Skip when running in CI (GitHub Actions sets `CI=true`). Used for tests
+    /// that require Metal/MLX runtime — see issue #75. GitHub-hosted macOS
+    /// runners are virtualized and can't load MLX's `default.metallib`.
+    static var requiresMetal: Self {
+        .enabled(
+            if: ProcessInfo.processInfo.environment["CI"] == nil,
+            "Skipped on CI: requires Metal/MLX runtime (issue #75)"
+        )
+    }
+}

--- a/Tests/MLXStructuredTests/TestErrorHandler.swift
+++ b/Tests/MLXStructuredTests/TestErrorHandler.swift
@@ -5,89 +5,89 @@
 //  Created by Ivan Petrukha on 18.09.2025.
 //
 
-import Testing
 @testable import MLXStructured
+import Testing
 
-@Test func testEmptyEBNFGrammar() async throws {
+@Test(.requiresMetal) func emptyEBNFGrammar() {
     #expect(performing: {
         let grammar = Grammar.ebnf("")
-        let _ = try XGrammar(vocab: ["a", "b", "c"], grammar: grammar)
+        _ = try XGrammar(vocab: ["a", "b", "c"], grammar: grammar)
     }, throws: { error in
         switch error {
         case XGrammarError.emptyGrammar:
-            return true
+            true
         default:
-            return false
+            false
         }
     })
 }
 
-@Test func testIncorrectEBNFGrammar() async throws {
+@Test(.requiresMetal) func incorrectEBNFGrammar() {
     #expect(performing: {
         let grammar = Grammar.ebnf("*")
-        let _ = try XGrammar(vocab: ["a", "b", "c"], grammar: grammar)
+        _ = try XGrammar(vocab: ["a", "b", "c"], grammar: grammar)
     }, throws: { error in
         switch error {
-        case XGrammarError.invalidGrammar(let message):
-            return message.contains("The root rule with name \"root\" is not found")
+        case let XGrammarError.invalidGrammar(message):
+            message.contains("The root rule with name \"root\" is not found")
         default:
-            return false
+            false
         }
     })
 }
 
-@Test func testEmptyRegexGrammar() async throws {
+@Test(.requiresMetal) func emptyRegexGrammar() {
     #expect(performing: {
         let grammar = Grammar.regex("")
-        let _ = try XGrammar(vocab: ["a", "b", "c"], grammar: grammar)
+        _ = try XGrammar(vocab: ["a", "b", "c"], grammar: grammar)
     }, throws: { error in
         switch error {
         case XGrammarError.emptyGrammar:
-            return true
+            true
         default:
-            return false
+            false
         }
     })
 }
 
-@Test func testIncorrectRegexGrammar() async throws {
+@Test(.requiresMetal) func incorrectRegexGrammar() {
     #expect(performing: {
         let grammar = Grammar.regex("*")
-        let _ = try XGrammar(vocab: ["a", "b", "c"], grammar: grammar)
+        _ = try XGrammar(vocab: ["a", "b", "c"], grammar: grammar)
     }, throws: { error in
         switch error {
-        case XGrammarError.invalidGrammar(let message):
-            return message.contains("Expect element, but got *")
+        case let XGrammarError.invalidGrammar(message):
+            message.contains("Expect element, but got *")
         default:
-            return false
+            false
         }
     })
 }
 
-@Test func testEmptyJSONSchemaGrammar() async throws {
+@Test(.requiresMetal) func emptyJSONSchemaGrammar() {
     #expect(performing: {
         let grammar = Grammar.schema("")
-        let _ = try XGrammar(vocab: ["a", "b", "c"], grammar: grammar)
+        _ = try XGrammar(vocab: ["a", "b", "c"], grammar: grammar)
     }, throws: { error in
         switch error {
         case XGrammarError.emptyGrammar:
-            return true
+            true
         default:
-            return false
+            false
         }
     })
 }
 
-@Test func testIncorrectJSONSchemaGrammar() async throws {
+@Test(.requiresMetal) func incorrectJSONSchemaGrammar() {
     #expect(performing: {
         let grammar = Grammar.schema(#"{"type": "foo"}"#)
-        let _ = try XGrammar(vocab: ["a", "b", "c"], grammar: grammar)
+        _ = try XGrammar(vocab: ["a", "b", "c"], grammar: grammar)
     }, throws: { error in
         switch error {
-        case XGrammarError.invalidGrammar(let message):
-            return message.contains("Unsupported type \"foo\"")
+        case let XGrammarError.invalidGrammar(message):
+            message.contains("Unsupported type \"foo\"")
         default:
-            return false
+            false
         }
     })
 }

--- a/Tests/MLXStructuredTests/TestGenerablePerformance.swift
+++ b/Tests/MLXStructuredTests/TestGenerablePerformance.swift
@@ -5,68 +5,86 @@
 //  Created by Rudrank Riyam on 21.09.2025.
 //
 
-import Testing
-@testable import MLXStructured
-import MLXLMCommon
-import MLXLLM
 import MLX
+import MLXLLM
+import MLXLMCommon
+@testable import MLXStructured
+import Testing
 
 #if canImport(FoundationModels)
-import FoundationModels
+    import FoundationModels
 #endif
 
 #if compiler(>=6.2)
-@available(macOS 26.0, iOS 26.0, *)
-@Generable
-private struct PerformanceRecord: Codable {
-    @Guide(description: "Simple string field")
-    let text: String
+    @available(macOS 26.0, iOS 26.0, *)
+    @Generable
+    private struct PerformanceRecord: Codable {
+        @Guide(description: "Simple string field")
+        let text: String
 
-    @Guide(description: "Simple integer field")
-    let value: Int
-}
-
-@Test func testGenerableLlamaPerformance() async throws {
-    guard #available(macOS 26.0, iOS 26.0, *) else { return }
-
-    let vocab = ["<eos>"] + (0...0xFFFF).compactMap({ UnicodeScalar($0).map(String.init) })
-    let model = LlamaModel(.init(
-        hiddenSize: 128,
-        hiddenLayers: 16,
-        intermediateSize: 512,
-        attentionHeads: 32,
-        rmsNormEps: 1e-5,
-        vocabularySize: vocab.count,
-        kvHeads: 8
-    ))
-
-    let grammar = try Grammar.generable(PerformanceRecord.self)
-    let grammarMatcher = try XGrammar(vocab: vocab, vocabType: 0, stopTokenIds: [0], grammar: grammar)
-    let processor = GrammarMaskedLogitProcessor(grammarMatcher: grammarMatcher)
-    let sampler = ArgMaxSampler()
-    let input = LMInput(tokens: MLXArray([1, 2, 3, 4, 5]))
-    let maxTokens = 512
-
-    let clock = ContinuousClock()
-    for _ in 0..<3 { // Warmup to stabilize results
-        let iterator = try TokenIterator(input: input, model: model, processor: nil, sampler: sampler, maxTokens: maxTokens)
-        let _ = Array(iterator)
+        @Guide(description: "Simple integer field")
+        let value: Int
     }
-    
-    let plainIterator = try TokenIterator(input: input, model: model, processor: nil, sampler: sampler, maxTokens: maxTokens)
-    let plainStart = clock.now
-    let _ = Array(plainIterator)
-    let plainDuration = clock.now - plainStart
 
-    let constrainedIterator = try TokenIterator(input: input, model: model, processor: processor, sampler: sampler, maxTokens: maxTokens)
-    let constrainedStart = clock.now
-    let _ = Array(constrainedIterator)
-    let constrainedDuration = clock.now - constrainedStart
+    @Test(.requiresMetal) func generableLlamaPerformance() throws {
+        guard #available(macOS 26.0, iOS 26.0, *) else { return }
 
-    let slowdown = (constrainedDuration / plainDuration) - 1
-    #expect(slowdown < 0.15)  // If it's slower by more than 15%, this indicates something is wrong
-    print("Plain duration: \(plainDuration)")
-    print("Generable constrained duration: \(constrainedDuration)")
-    print("Generable constrained decoding slower by \(slowdown.formatted(.percent))")
-}
+        let vocab = ["<eos>"] + (0 ... 0xFFFF).compactMap { UnicodeScalar($0).map(String.init) }
+        let model = LlamaModel(.init(
+            hiddenSize: 128,
+            hiddenLayers: 16,
+            intermediateSize: 512,
+            attentionHeads: 32,
+            rmsNormEps: 1e-5,
+            vocabularySize: vocab.count,
+            kvHeads: 8
+        ))
+
+        let grammar = try Grammar.generable(PerformanceRecord.self)
+        let grammarMatcher = try XGrammar(vocab: vocab, vocabType: 0, stopTokenIds: [0], grammar: grammar)
+        let processor = GrammarMaskedLogitProcessor(grammarMatcher: grammarMatcher)
+        let sampler = ArgMaxSampler()
+        let input = LMInput(tokens: MLXArray([1, 2, 3, 4, 5]))
+        let maxTokens = 512
+
+        let clock = ContinuousClock()
+        for _ in 0 ..< 3 { // Warmup to stabilize results
+            let iterator = try TokenIterator(
+                input: input,
+                model: model,
+                processor: nil,
+                sampler: sampler,
+                maxTokens: maxTokens
+            )
+            _ = Array(iterator)
+        }
+
+        let plainIterator = try TokenIterator(
+            input: input,
+            model: model,
+            processor: nil,
+            sampler: sampler,
+            maxTokens: maxTokens
+        )
+        let plainStart = clock.now
+        _ = Array(plainIterator)
+        let plainDuration = clock.now - plainStart
+
+        let constrainedIterator = try TokenIterator(
+            input: input,
+            model: model,
+            processor: processor,
+            sampler: sampler,
+            maxTokens: maxTokens
+        )
+        let constrainedStart = clock.now
+        _ = Array(constrainedIterator)
+        let constrainedDuration = clock.now - constrainedStart
+
+        let slowdown = (constrainedDuration / plainDuration) - 1
+        #expect(slowdown < 0.15) // If it's slower by more than 15%, this indicates something is wrong
+        print("Plain duration: \(plainDuration)")
+        print("Generable constrained duration: \(constrainedDuration)")
+        print("Generable constrained decoding slower by \(slowdown.formatted(.percent))")
+    }
 #endif

--- a/Tests/MLXStructuredTests/TestGrammarMatcher.swift
+++ b/Tests/MLXStructuredTests/TestGrammarMatcher.swift
@@ -5,22 +5,22 @@
 //  Created by Ivan Petrukha on 16.09.2025.
 //
 
-import Testing
-@testable import MLXStructured
 import MLX
+@testable import MLXStructured
+import Testing
 
-@Test func testEBNFGrammarMatcher() async throws {
+@Test(.requiresMetal) func eBNFGrammarMatcher() throws {
     let vocab = ["Y", "E", "S", "N", "O"]
     let grammar = Grammar.ebnf(#"root ::= ("YES" | "NO")"#)
     let grammarMatcher = try XGrammar(vocab: vocab, stopTokenIds: [], grammar: grammar)
-    
-    let advances: [Int] = "YES".map(String.init).compactMap({ vocab.firstIndex(of: $0) })
+
+    let advances: [Int] = "YES".map(String.init).compactMap { vocab.firstIndex(of: $0) }
     let expectations: [[Int]] = [
         [1, 0, 0, 1, 0], // "Y" or "N"
         [0, 1, 0, 0, 0], // "E"
         [0, 0, 1, 0, 0], // "S"
     ]
-    
+
     for (expectation, advance) in zip(expectations, advances) {
         let mask = grammarMatcher.nextTokenMask()
         let allowed = mask.exp().asArray(Int.self)
@@ -29,19 +29,19 @@ import MLX
     }
 }
 
-@Test func testEBNFGrammarMatcherWithEOSToken() async throws {
+@Test(.requiresMetal) func eBNFGrammarMatcherWithEOSToken() throws {
     let vocab = ["<eos>", "Y", "E", "S", "N", "O"]
     let grammar = Grammar.ebnf(#"root ::= ("YES" | "NO")"#)
     let grammarMatcher = try XGrammar(vocab: vocab, stopTokenIds: [0], grammar: grammar)
-    
-    let advances: [Int] = "YES".map(String.init).compactMap({ vocab.firstIndex(of: $0) }) + [0]
+
+    let advances: [Int] = "YES".map(String.init).compactMap { vocab.firstIndex(of: $0) } + [0]
     let expectations: [[Int]] = [
         [0, 1, 0, 0, 1, 0], // "Y" or "N"
         [0, 0, 1, 0, 0, 0], // "E"
         [0, 0, 0, 1, 0, 0], // "S"
         [1, 0, 0, 0, 0, 0], // "<eos>"
     ]
-    
+
     for (expectation, advance) in zip(expectations, advances) {
         let mask = grammarMatcher.nextTokenMask()
         let allowed = mask.exp().asArray(Int.self)
@@ -50,12 +50,12 @@ import MLX
     }
 }
 
-@Test func testRegexEmailGrammarMatcher() async throws {
+@Test(.requiresMetal) func regexEmailGrammarMatcher() throws {
     let vocab = ["<eos>", "a", "b", "c", "@", "."]
     let grammar = Grammar.regex(#"^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}$"#) // Simple email regex
     let grammarMatcher = try XGrammar(vocab: vocab, stopTokenIds: [0], grammar: grammar)
-    
-    let advances: [Int] = "abc@ab.cc".map(String.init).compactMap({ vocab.firstIndex(of: $0) }) + [0]
+
+    let advances: [Int] = "abc@ab.cc".map(String.init).compactMap { vocab.firstIndex(of: $0) } + [0]
     let expectations: [[Int]] = [
         [0, 1, 1, 1, 0, 1], // Not "@" nor "<eos>
         [0, 1, 1, 1, 1, 1], // Not "<eos>"
@@ -68,7 +68,7 @@ import MLX
         [0, 1, 1, 1, 0, 1], // Not "@" nor "<eos>"
         [1, 1, 1, 1, 0, 1], // Not "@"
     ]
-    
+
     for (expectation, advance) in zip(expectations, advances) {
         let mask = grammarMatcher.nextTokenMask()
         let allowed = mask.exp().asArray(Int.self)
@@ -77,12 +77,12 @@ import MLX
     }
 }
 
-@Test func testRegexPhoneGrammarMatcher() async throws {
+@Test(.requiresMetal) func regexPhoneGrammarMatcher() throws {
     let vocab = ["<eos>", "+", "1", "2", "3", "4", "5", "6", "7", "8", "9", "0", " "]
     let grammar = Grammar.regex(#"^\+[0-9\s]{7,15}$"#) // Simple phone regex
     let grammarMatcher = try XGrammar(vocab: vocab, stopTokenIds: [0], grammar: grammar)
-    
-    let advances: [Int] = "+1 234 5678".map(String.init).compactMap({ vocab.firstIndex(of: $0) }) + [0]
+
+    let advances: [Int] = "+1 234 5678".map(String.init).compactMap { vocab.firstIndex(of: $0) } + [0]
     let expectations: [[Int]] = [
         [0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], // "+"
         [0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1], // Any decimal but not "+" or "<eos>"
@@ -97,7 +97,7 @@ import MLX
         [1, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1], // Any decimal but not "+"
         [1, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1], // Any decimal but not "+"
     ]
-    
+
     for (expectation, advance) in zip(expectations, advances) {
         let mask = grammarMatcher.nextTokenMask()
         let allowed = mask.exp().asArray(Int.self)
@@ -106,12 +106,12 @@ import MLX
     }
 }
 
-@Test func testJSONSchemaGrammarMatcher() async throws {
+@Test(.requiresMetal) func jSONSchemaGrammarMatcher() throws {
     let vocab = ["<eos>", "{", "}", ":", " ", "\"", "a", "b"]
     let grammar = try Grammar.schema(.object(properties: ["a": .string()], required: ["a"]))
     let grammarMatcher = try XGrammar(vocab: vocab, stopTokenIds: [0], grammar: grammar)
-    
-    let advances: [Int] = #"{"a": "b"}"#.map(String.init).compactMap({ vocab.firstIndex(of: $0) }) + [0]
+
+    let advances: [Int] = #"{"a": "b"}"#.map(String.init).compactMap { vocab.firstIndex(of: $0) } + [0]
     let expectations: [[Int]] = [
         [0, 1, 0, 0, 0, 0, 0, 0], // "{"
         [0, 0, 0, 0, 0, 1, 0, 0], // """
@@ -125,7 +125,7 @@ import MLX
         [0, 0, 1, 0, 0, 0, 0, 0], // "}"
         [1, 0, 0, 0, 0, 0, 0, 0], // "<eos>"
     ]
-    
+
     for (expectation, advance) in zip(expectations, advances) {
         let mask = grammarMatcher.nextTokenMask()
         let allowed = mask.exp().asArray(Int.self)

--- a/Tests/MLXStructuredTests/TestHelpers.swift
+++ b/Tests/MLXStructuredTests/TestHelpers.swift
@@ -1,0 +1,14 @@
+import Foundation
+import Testing
+
+extension Trait where Self == Testing.ConditionTrait {
+    /// Skip when running in CI (GitHub Actions sets `CI=true`). Used for tests
+    /// that require Metal/MLX runtime — see issue #75. GitHub-hosted macOS
+    /// runners are virtualized and can't load MLX's `default.metallib`.
+    static var requiresMetal: Self {
+        .enabled(
+            if: ProcessInfo.processInfo.environment["CI"] == nil,
+            "Skipped on CI: requires Metal/MLX runtime (issue #75)"
+        )
+    }
+}

--- a/Tests/MLXStructuredTests/TestMemoryLeaks.swift
+++ b/Tests/MLXStructuredTests/TestMemoryLeaks.swift
@@ -5,16 +5,16 @@
 //  Created by Ivan Petrukha on 21.09.2025.
 //
 
-import Testing
 import Foundation
 @testable import MLXStructured
+import Testing
 
-// This test never fails, but it is still useful for checking memory in the profiler
-// Memory usage is currently stable and never exceeds 30 MB
-@Test func testMemoryLeaks() async throws {
-    for _ in 0..<100 {
+/// This test never fails, but it is still useful for checking memory in the profiler
+/// Memory usage is currently stable and never exceeds 30 MB
+@Test(.requiresMetal) func memoryLeaks() throws {
+    for _ in 0 ..< 100 {
         try autoreleasepool {
-            let vocab = ["<eos>"] + (0...0xFFFF).compactMap({ UnicodeScalar($0).map(String.init) })
+            let vocab = ["<eos>"] + (0 ... 0xFFFF).compactMap { UnicodeScalar($0).map(String.init) }
             let grammar = try Grammar.schema(.object(properties: ["a": .string(), "b": .integer()]))
             let grammarMatcher = try XGrammar(vocab: vocab, vocabType: 0, stopTokenIds: [0], grammar: grammar)
             _ = grammarMatcher.nextTokenMask()

--- a/Tests/MLXStructuredTests/TestPerformance.swift
+++ b/Tests/MLXStructuredTests/TestPerformance.swift
@@ -5,14 +5,14 @@
 //  Created by Ivan Petrukha on 19.09.2025.
 //
 
-import Testing
-@testable import MLXStructured
-import MLXLMCommon
-import MLXLLM
 import MLX
+import MLXLLM
+import MLXLMCommon
+@testable import MLXStructured
+import Testing
 
-@Test func testLlamaPerformance() async throws {
-    let vocab = ["<eos>"] + (0...0xFFFF).compactMap({ UnicodeScalar($0).map(String.init) })
+@Test(.requiresMetal) func llamaPerformance() throws {
+    let vocab = ["<eos>"] + (0 ... 0xFFFF).compactMap { UnicodeScalar($0).map(String.init) }
     let model = LlamaModel(.init(
         hiddenSize: 128,
         hiddenLayers: 16,
@@ -22,39 +22,57 @@ import MLX
         vocabularySize: vocab.count,
         kvHeads: 8
     ))
-        
+
     let grammar = try Grammar.schema(.object(
         properties: [
             "a": .string(),
-            "b": .integer()
+            "b": .integer(),
         ], required: [
             "a",
-            "b"
+            "b",
         ]
     ))
-    
+
     let grammarMatcher = try XGrammar(vocab: vocab, vocabType: 0, stopTokenIds: [0], grammar: grammar)
     let processor = GrammarMaskedLogitProcessor(grammarMatcher: grammarMatcher)
     let sampler = ArgMaxSampler()
     let input = LMInput(tokens: MLXArray([1, 2, 3, 4, 5]))
     let maxTokens = 512 // Without a stopping criterion, both tests generate up to the maximum number of tokens
-    
+
     let clock = ContinuousClock()
-    for _ in 0..<3 { // Warmup to stabilize results
-        let iterator = try TokenIterator(input: input, model: model, processor: nil, sampler: sampler, maxTokens: maxTokens)
-        let _ = Array(iterator)
+    for _ in 0 ..< 3 { // Warmup to stabilize results
+        let iterator = try TokenIterator(
+            input: input,
+            model: model,
+            processor: nil,
+            sampler: sampler,
+            maxTokens: maxTokens
+        )
+        _ = Array(iterator)
     }
-    
-    let plainIterator = try TokenIterator(input: input, model: model, processor: nil, sampler: sampler, maxTokens: maxTokens)
+
+    let plainIterator = try TokenIterator(
+        input: input,
+        model: model,
+        processor: nil,
+        sampler: sampler,
+        maxTokens: maxTokens
+    )
     let plainStart = clock.now
-    let _ = Array(plainIterator)
+    _ = Array(plainIterator)
     let plainDuration = clock.now - plainStart
-    
-    let constrainedIterator = try TokenIterator(input: input, model: model, processor: processor, sampler: sampler, maxTokens: maxTokens)
+
+    let constrainedIterator = try TokenIterator(
+        input: input,
+        model: model,
+        processor: processor,
+        sampler: sampler,
+        maxTokens: maxTokens
+    )
     let constrainedStart = clock.now
-    let _ = Array(constrainedIterator)
+    _ = Array(constrainedIterator)
     let constrainedDuration = clock.now - constrainedStart
-    
+
     let slowdown = (constrainedDuration / plainDuration) - 1
     #expect(slowdown < 0.15) // If it's slower by more than 15%, this indicates something is wrong
     print("Plain duration: \(plainDuration)")


### PR DESCRIPTION
Two small follow-ups, packaged together so the repo lands ready for first release in one PR.

## 1. Skip MLX-runtime tests on CI (Closes #75)

GitHub-hosted macos-15 runners are virtualized M1 instances without Metal, so anything that triggers an MLX array op exits with "Failed to load the default metallib". swift build works fine; only test execution that touches the runtime crashes.

This PR introduces a shared Trait.requiresMetal helper (in Tests/MLXStructuredTests/TestHelpers.swift and Tests/CastTests/TestHelpers.swift) that gates tests on ProcessInfo.processInfo.environment["CI"] == nil. Applied to:

Tests/MLXStructuredTests/ (every test - all hit XGrammar or MLXArray):
- TestErrorHandler.swift - 6 tests
- TestGrammarMatcher.swift - 5 tests
- TestMemoryLeaks.swift - 1 test
- TestPerformance.swift - 1 test
- TestGenerablePerformance.swift - 1 test

Tests/CastTests/GPUSafetyTests.swift - 1 test:
- testCleanupGPUDoesNotCrash (calls Stream.gpu.synchronize() / Memory.clearCache())

The other GPUSafetyTests only register an error-handler callback (no Metal needed), so they keep running on CI. Macro / schema / property-wrapper / validator / prompt-engine / JSON-repair / classify / lifecycle / timeout tests continue to run on CI.

## 2. Pin SPM install snippet to v0.1.0

README.md now uses .package(url: ..., from: "0.1.0") instead of branch: "main". The v0.1.0 tag is cut by the Release workflow after this PR merges.

## Test plan

- [x] CI=true swift test: 155 tests pass, 15 tests skipped with the Metal-required reason string
- [x] swift test (no CI): gated tests run normally; MLX runtime errors locally are pre-existing on stage and unrelated to this change
- [x] swift build clean

## Notes

- SwiftFormat / SwiftLint pre-tool hooks reformatted the touched test files (import ordering, function-name test prefix removal, multi-line argument wrapping). Behavior is unchanged.
- The shared trait helper is duplicated in two test targets because SPM has no shared test-utility module concept. Two five-line files is cheaper than a TestSupport target.