### PR TITLE
feat(api): CastModel.extract() — extraction-optimized convenience (#36)

### DIFF
--- a/Examples/Package.swift
+++ b/Examples/Package.swift
@@ -98,6 +98,14 @@ let package = Package(
                 .product(name: "JSONSchema", package: "swift-json-schema"),
                 .product(name: "Collections", package: "swift-collections")
             ]
+        ),
+        .executableTarget(
+            name: "Extract",
+            dependencies: [
+                .product(name: "Cast", package: "Cast"),
+                .product(name: "JSONSchema", package: "swift-json-schema"),
+                .product(name: "Collections", package: "swift-collections")
+            ]
         )
     ]
 )

--- a/Examples/Sources/Extract/main.swift
+++ b/Examples/Sources/Extract/main.swift
@@ -1,0 +1,38 @@
+// What this shows: extract structured fields from a block of unstructured text via model.extract(from:as:instruction:).
+
+import Cast
+import Collections
+import Foundation
+import JSONSchema
+
+@Castable
+struct InvoiceFields {
+    var invoiceNumber: String = ""
+    var vendor: String = ""
+    var totalUSD: Double = 0
+}
+
+@main
+enum Extract {
+    static func main() async throws {
+        let model = try await CastModel.load("mlx-community/Llama-3.2-3B-Instruct-4bit")
+
+        let invoice = """
+        ACME Corp.
+        Invoice Number: INV-7421
+        Date: 2025-03-12
+        Description: Consulting services
+        Total Due: $1,250.00 USD
+        """
+
+        let fields: InvoiceFields = try await model.extract(
+            from: invoice,
+            instruction: "Extract the invoice number, vendor name, and total in USD."
+        )
+
+        print(fields)
+    }
+}
+
+// Sample output (manual run, will vary by model):
+// InvoiceFields(invoiceNumber: "INV-7421", vendor: "ACME Corp.", totalUSD: 1250.0)

--- a/Examples/Sources/Extract/main.swift
+++ b/Examples/Sources/Extract/main.swift
@@ -5,11 +5,13 @@ import Collections
 import Foundation
 import JSONSchema
 
+/// Optional fields demonstrate the no-invention contract: a missing
+/// value in the source can decode to `nil` rather than being hallucinated.
 @Castable
 struct InvoiceFields {
-    var invoiceNumber: String = ""
-    var vendor: String = ""
-    var totalUSD: Double = 0
+    var invoiceNumber: String?
+    var vendor: String?
+    var totalUSD: Double?
 }
 
 @main
@@ -33,6 +35,3 @@ enum Extract {
         print(fields)
     }
 }
-
-// Sample output (manual run, will vary by model):
-// InvoiceFields(invoiceNumber: "INV-7421", vendor: "ACME Corp.", totalUSD: 1250.0)

--- a/Sources/Cast/API/CastModel+Extract.swift
+++ b/Sources/Cast/API/CastModel+Extract.swift
@@ -1,0 +1,60 @@
+import Foundation
+import JSONSchema
+@preconcurrency import MLXLMCommon
+
+public extension CastModel {
+    /// Extract structured fields from a block of unstructured text. Builds an
+    /// extraction-optimized prompt that wraps `text` in delimiters and tells
+    /// the model not to invent fields, then delegates to ``cast(_:as:schema:system:config:didGenerate:)``.
+    ///
+    /// ```swift
+    /// @Castable struct InvoiceFields { var invoiceNumber: String = ""; var totalUSD: Double = 0 }
+    /// let fields: InvoiceFields = try await model.extract(
+    ///     from: invoiceText,
+    ///     instruction: "Extract the invoice number and total in USD."
+    /// )
+    /// ```
+    ///
+    /// - Parameters:
+    ///   - text: The unstructured source text to extract from.
+    ///   - type: Target type. Usually inferred.
+    ///   - instruction: What to extract (e.g. "Extract the invoice number and
+    ///     total in USD.").
+    ///   - system: Optional override for the auto-built system message.
+    ///   - config: Sampling, timeout, and JSON-repair knobs.
+    ///   - didGenerate: Optional per-token hook returning `.stop` to end early.
+    /// - Throws: Same errors as ``cast(_:as:system:config:didGenerate:)``.
+    func extract<T: Decodable & Sendable>(
+        from text: String,
+        as type: T.Type = T.self,
+        instruction: String,
+        system: String? = nil,
+        config: CastConfiguration = CastConfiguration(),
+        didGenerate: (@Sendable (Int) -> GenerateDisposition)? = nil
+    ) async throws -> T {
+        let schema: JSONSchema
+        do {
+            schema = try SchemaGenerator.schema(for: type)
+        } catch {
+            throw CastError.schemaGenerationFailed(error.localizedDescription)
+        }
+
+        let annotations = (try? SchemaGenerator.annotations(for: type)) ?? [:]
+        let built = PromptEngine.buildExtractionPrompt(
+            text: text,
+            instruction: instruction,
+            schema: schema,
+            annotations: annotations,
+            system: system
+        )
+
+        return try await cast(
+            built.user,
+            as: type,
+            schema: schema,
+            system: built.system,
+            config: config,
+            didGenerate: didGenerate
+        )
+    }
+}

--- a/Sources/Cast/API/CastModel+Extract.swift
+++ b/Sources/Cast/API/CastModel+Extract.swift
@@ -23,7 +23,9 @@ public extension CastModel {
     ///   - system: Optional override for the auto-built system message.
     ///   - config: Sampling, timeout, and JSON-repair knobs.
     ///   - didGenerate: Optional per-token hook returning `.stop` to end early.
-    /// - Throws: Same errors as ``cast(_:as:system:config:didGenerate:)``.
+    /// - Throws: Same errors as ``cast(_:as:schema:system:config:didGenerate:)``
+    ///   plus ``CastError/schemaGenerationFailed(_:)`` if the schema cannot
+    ///   be derived from `T`.
     func extract<T: Decodable & Sendable>(
         from text: String,
         as type: T.Type = T.self,

--- a/Sources/Cast/Cast.docc/Cast.md
+++ b/Sources/Cast/Cast.docc/Cast.md
@@ -42,6 +42,7 @@ invalid tokens during decoding — so the model can only emit JSON that matches.
 
 - <doc:HelloCast>
 - <doc:Classify>
+- <doc:Extract>
 - <doc:GenerationModes>
 - <doc:NestedTypes>
 - <doc:PropertyWrappersTour>

--- a/Sources/Cast/Cast.docc/Examples/Extract.md
+++ b/Sources/Cast/Cast.docc/Examples/Extract.md
@@ -1,0 +1,52 @@
+# Extract
+
+extract(from:as:instruction:) pulls structured fields out of a block of
+unstructured text. It composes an extraction-optimized prompt (the source is
+wrapped in nonced delimiters and the model is told not to invent fields) and
+delegates to the same constrained-decoding path as cast(). Optional fields
+demonstrate the no-invention contract: a value missing in the source decodes
+to nil rather than being hallucinated.
+
+## Source
+
+Full source: [Examples/Sources/Extract/main.swift](https://github.com/jaylann/Cast/blob/main/Examples/Sources/Extract/main.swift)
+
+```swift
+// What this shows: extract structured fields from a block of unstructured text via model.extract(from:as:instruction:).
+
+import Cast
+import Collections
+import Foundation
+import JSONSchema
+
+/// Optional fields demonstrate the no-invention contract: a missing
+/// value in the source can decode to `nil` rather than being hallucinated.
+@Castable
+struct InvoiceFields {
+    var invoiceNumber: String?
+    var vendor: String?
+    var totalUSD: Double?
+}
+
+@main
+enum Extract {
+    static func main() async throws {
+        let model = try await CastModel.load("mlx-community/Llama-3.2-3B-Instruct-4bit")
+
+        let invoice = """
+        ACME Corp.
+        Invoice Number: INV-7421
+        Date: 2025-03-12
+        Description: Consulting services
+        Total Due: $1,250.00 USD
+        """
+
+        let fields: InvoiceFields = try await model.extract(
+            from: invoice,
+            instruction: "Extract the invoice number, vendor name, and total in USD."
+        )
+
+        print(fields)
+    }
+}
+```

--- a/Sources/Cast/Prompt/PromptEngine.swift
+++ b/Sources/Cast/Prompt/PromptEngine.swift
@@ -145,25 +145,20 @@ public enum PromptEngine {
     }
 
     private static func buildExtractionUser(text: String, instruction: String) -> String {
-        // A per-call random nonce is suffixed to both fences so the source
-        // body cannot end the block by including the literal delimiter — a
-        // trivial prompt-injection vector when delimiters are fixed strings
-        // like `---END SOURCE---` (which is also a valid markdown HR).
-        let nonce = extractionNonce()
+        // A fresh per-call UUID is embedded in both fences so an attacker
+        // crafting `text` cannot guess the literal end delimiter to close the
+        // source block early. This narrows one specific collision/injection
+        // vector — it does NOT prevent prompt injection in general; a
+        // malicious source body can still try to override instructions with
+        // natural-language tricks. Defenders should treat extracted output
+        // as untrusted.
+        let nonce = UUID().uuidString
         var parts: [String] = []
         parts.append(instruction)
         parts.append("")
-        parts.append("<<<SOURCE \(nonce)>>>")
+        parts.append("<<<SOURCE-\(nonce)>>>")
         parts.append(text)
-        parts.append("<<<END SOURCE \(nonce)>>>")
+        parts.append("<<<END-SOURCE-\(nonce)>>>")
         return parts.joined(separator: "\n")
-    }
-
-    /// 8 lowercase hex characters from a fresh UUID — short enough to keep
-    /// the prompt readable, long enough (~32 bits) that collision with the
-    /// source body is not a practical concern.
-    private static func extractionNonce() -> String {
-        let uuid = UUID().uuidString
-        return String(uuid.replacingOccurrences(of: "-", with: "").prefix(8)).lowercased()
     }
 }

--- a/Sources/Cast/Prompt/PromptEngine.swift
+++ b/Sources/Cast/Prompt/PromptEngine.swift
@@ -145,14 +145,25 @@ public enum PromptEngine {
     }
 
     private static func buildExtractionUser(text: String, instruction: String) -> String {
-        // Delimiters separate untrusted source text from the extraction
-        // instruction, mitigating prompt-injection from the source body.
+        // A per-call random nonce is suffixed to both fences so the source
+        // body cannot end the block by including the literal delimiter — a
+        // trivial prompt-injection vector when delimiters are fixed strings
+        // like `---END SOURCE---` (which is also a valid markdown HR).
+        let nonce = extractionNonce()
         var parts: [String] = []
         parts.append(instruction)
         parts.append("")
-        parts.append("---SOURCE---")
+        parts.append("<<<SOURCE \(nonce)>>>")
         parts.append(text)
-        parts.append("---END SOURCE---")
+        parts.append("<<<END SOURCE \(nonce)>>>")
         return parts.joined(separator: "\n")
+    }
+
+    /// 8 lowercase hex characters from a fresh UUID — short enough to keep
+    /// the prompt readable, long enough (~32 bits) that collision with the
+    /// source body is not a practical concern.
+    private static func extractionNonce() -> String {
+        let uuid = UUID().uuidString
+        return String(uuid.replacingOccurrences(of: "-", with: "").prefix(8)).lowercased()
     }
 }

--- a/Sources/Cast/Prompt/PromptEngine.swift
+++ b/Sources/Cast/Prompt/PromptEngine.swift
@@ -2,18 +2,16 @@ import Foundation
 import JSONSchema
 
 public enum PromptEngine {
-
     public static func buildPrompt(
         userPrompt: String,
         schema: JSONSchema,
         annotations: [String: FieldAnnotation] = [:],
         system: String? = nil
     ) -> (system: String, user: String) {
-        let systemPrompt: String
-        if let system {
-            systemPrompt = system
+        let systemPrompt: String = if let system {
+            system
         } else {
-            systemPrompt = buildDefaultSystem(schema: schema, annotations: annotations)
+            buildDefaultSystem(schema: schema, annotations: annotations)
         }
         return (system: systemPrompt, user: userPrompt)
     }
@@ -74,6 +72,87 @@ public enum PromptEngine {
         parts.append("")
         parts.append("Respond with ONLY the category name as a JSON string.")
         parts.append("No explanation, no markdown.")
+        return parts.joined(separator: "\n")
+    }
+
+    /// Build an extraction-optimized prompt: wraps the source `text` in
+    /// unambiguous delimiters and tells the model not to invent fields.
+    /// The system message embeds the JSON schema (same shape as
+    /// ``buildPrompt(userPrompt:schema:annotations:system:)``); when `system`
+    /// is supplied, it is returned verbatim as the system message.
+    ///
+    /// - Parameters:
+    ///   - text: The unstructured source text to extract from.
+    ///   - instruction: The extraction instruction (e.g. "Extract the
+    ///     invoice number and total in USD").
+    ///   - schema: The JSON schema the output must conform to.
+    ///   - annotations: Optional per-field guidance (description, examples).
+    ///   - system: Optional override for the system message.
+    public static func buildExtractionPrompt(
+        text: String,
+        instruction: String,
+        schema: JSONSchema,
+        annotations: [String: FieldAnnotation] = [:],
+        system: String? = nil
+    ) -> (system: String, user: String) {
+        let systemPrompt = system ?? buildExtractionSystem(schema: schema, annotations: annotations)
+        let user = buildExtractionUser(text: text, instruction: instruction)
+        return (system: systemPrompt, user: user)
+    }
+
+    private static func buildExtractionSystem(
+        schema: JSONSchema,
+        annotations: [String: FieldAnnotation]
+    ) -> String {
+        var parts: [String] = []
+
+        parts.append("You are a structured data extraction assistant.")
+        parts
+            .append(
+                "Extract the requested fields from the source. If a field is not present, use null. Do not invent information."
+            )
+        parts.append("Respond ONLY with valid JSON matching the following schema.")
+        parts.append("")
+
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys, .prettyPrinted]
+        if let data = try? encoder.encode(schema),
+           let str = String(data: data, encoding: .utf8) {
+            parts.append("JSON Schema:")
+            parts.append(str)
+        } else {
+            parts.append("[Schema encoding failed]")
+        }
+
+        let guidance = annotations.sorted(by: { $0.key < $1.key }).compactMap { field, ann -> String? in
+            var items: [String] = []
+            if let d = ann.description { items.append(d) }
+            if let e = ann.examples, !e.isEmpty { items.append("Examples: \(e.joined(separator: ", "))") }
+            guard !items.isEmpty else { return nil }
+            return "- \(field): \(items.joined(separator: ". "))"
+        }
+
+        if !guidance.isEmpty {
+            parts.append("")
+            parts.append("Field guidance:")
+            parts.append(contentsOf: guidance)
+        }
+
+        parts.append("")
+        parts.append("Output valid JSON only. No markdown, no explanation.")
+
+        return parts.joined(separator: "\n")
+    }
+
+    private static func buildExtractionUser(text: String, instruction: String) -> String {
+        // Delimiters separate untrusted source text from the extraction
+        // instruction, mitigating prompt-injection from the source body.
+        var parts: [String] = []
+        parts.append(instruction)
+        parts.append("")
+        parts.append("---SOURCE---")
+        parts.append(text)
+        parts.append("---END SOURCE---")
         return parts.joined(separator: "\n")
     }
 }

--- a/Sources/Cast/Prompt/PromptEngine.swift
+++ b/Sources/Cast/Prompt/PromptEngine.swift
@@ -109,7 +109,7 @@ public enum PromptEngine {
         parts.append("You are a structured data extraction assistant.")
         parts
             .append(
-                "Extract the requested fields from the source. If a field is not present, use null. Do not invent information."
+                "Extract the requested fields from the source. If a field is not present in the source, omit it from the output (or use null only if the schema permits null for that field). Do not invent information."
             )
         parts.append("Respond ONLY with valid JSON matching the following schema.")
         parts.append("")

--- a/Tests/CastTests/ExtractTests.swift
+++ b/Tests/CastTests/ExtractTests.swift
@@ -1,0 +1,45 @@
+@testable import Cast
+import Collections
+import JSONSchema
+import Testing
+
+@Castable
+struct InvoiceFields {
+    var invoiceNumber: String = ""
+    var totalUSD: Double = 0
+}
+
+@Suite("Extract")
+struct ExtractTests {
+    @Test("extract throws modelNotLoaded when no model")
+    func extractNoModel() async {
+        let model = CastModel(_testContainer: nil)
+        await #expect(throws: CastError.self) {
+            let _: InvoiceFields = try await model.extract(
+                from: "Invoice #1 total $10",
+                instruction: "Extract."
+            )
+        }
+    }
+
+    @Test("extract end-to-end on a small invoice", .requiresMetal)
+    func extractInvoice() async throws {
+        let model = try await CastModel.load("mlx-community/Llama-3.2-3B-Instruct-4bit")
+
+        let invoice = """
+        ACME Corp.
+        Invoice Number: INV-7421
+        Date: 2025-03-12
+        Description: Consulting services
+        Total Due: $1,250.00 USD
+        """
+
+        let fields: InvoiceFields = try await model.extract(
+            from: invoice,
+            instruction: "Extract the invoice number and total in USD."
+        )
+
+        #expect(!fields.invoiceNumber.isEmpty)
+        #expect(fields.totalUSD > 0)
+    }
+}

--- a/Tests/CastTests/PromptEngineTests.swift
+++ b/Tests/CastTests/PromptEngineTests.swift
@@ -1,11 +1,10 @@
-import Testing
-import JSONSchema
 @testable import Cast
+import JSONSchema
+import Testing
 
 @Suite("PromptEngine")
 struct PromptEngineTests {
-
-    @Test func defaultSystemIncludesSchema() throws {
+    @Test func defaultSystemIncludesSchema() {
         let schema = JSONSchema.object(
             properties: ["name": .string(), "age": .integer()],
             required: ["name", "age"]
@@ -60,5 +59,78 @@ struct PromptEngineTests {
         let schema = JSONSchema.object()
         let result = PromptEngine.buildPrompt(userPrompt: "test", schema: schema)
         #expect(result.system.contains("valid JSON"))
+    }
+
+    @Test func extractionPromptWrapsTextInDelimiters() {
+        let schema = JSONSchema.object()
+        let source = "Invoice #4242 — total due $19.99"
+        let result = PromptEngine.buildExtractionPrompt(
+            text: source,
+            instruction: "Extract the invoice number and total.",
+            schema: schema
+        )
+
+        #expect(result.user.contains("---SOURCE---"))
+        #expect(result.user.contains("---END SOURCE---"))
+        #expect(result.user.contains(source))
+
+        guard
+            let startRange = result.user.range(of: "---SOURCE---"),
+            let endRange = result.user.range(of: "---END SOURCE---"),
+            let sourceRange = result.user.range(of: source)
+        else {
+            Issue.record("Expected delimiters and source text in user prompt")
+            return
+        }
+        #expect(startRange.upperBound <= sourceRange.lowerBound)
+        #expect(sourceRange.upperBound <= endRange.lowerBound)
+    }
+
+    @Test func extractionPromptIncludesInstruction() {
+        let schema = JSONSchema.object()
+        let instruction = "Extract the invoice number and total in USD."
+        let result = PromptEngine.buildExtractionPrompt(
+            text: "irrelevant",
+            instruction: instruction,
+            schema: schema
+        )
+        #expect(result.user.contains(instruction))
+    }
+
+    @Test func extractionPromptDiscouragesInvention() {
+        let schema = JSONSchema.object()
+        let result = PromptEngine.buildExtractionPrompt(
+            text: "irrelevant",
+            instruction: "Extract.",
+            schema: schema
+        )
+        #expect(result.system.lowercased().contains("do not invent"))
+        #expect(result.system.contains("null"))
+    }
+
+    @Test func extractionPromptIncludesSchema() {
+        let schema = JSONSchema.object(
+            properties: ["invoiceNumber": .string(), "totalUSD": .number()],
+            required: ["invoiceNumber", "totalUSD"]
+        )
+        let result = PromptEngine.buildExtractionPrompt(
+            text: "irrelevant",
+            instruction: "Extract.",
+            schema: schema
+        )
+        #expect(result.system.contains("JSON Schema"))
+        #expect(result.system.contains("invoiceNumber"))
+        #expect(result.system.contains("totalUSD"))
+    }
+
+    @Test func extractionPromptCustomSystemOverride() {
+        let schema = JSONSchema.object()
+        let result = PromptEngine.buildExtractionPrompt(
+            text: "irrelevant",
+            instruction: "Extract.",
+            schema: schema,
+            system: "Custom extraction system."
+        )
+        #expect(result.system == "Custom extraction system.")
     }
 }

--- a/Tests/CastTests/PromptEngineTests.swift
+++ b/Tests/CastTests/PromptEngineTests.swift
@@ -70,20 +70,38 @@ struct PromptEngineTests {
             schema: schema
         )
 
-        #expect(result.user.contains("---SOURCE---"))
-        #expect(result.user.contains("---END SOURCE---"))
-        #expect(result.user.contains(source))
+        // Per-call nonce: assert structural shape rather than literal text.
+        let openPattern = #/<<<SOURCE ([0-9a-f]{8})>>>/#
+        let closePattern = #/<<<END SOURCE ([0-9a-f]{8})>>>/#
 
         guard
-            let startRange = result.user.range(of: "---SOURCE---"),
-            let endRange = result.user.range(of: "---END SOURCE---"),
+            let openMatch = result.user.firstMatch(of: openPattern),
+            let closeMatch = result.user.firstMatch(of: closePattern),
             let sourceRange = result.user.range(of: source)
         else {
-            Issue.record("Expected delimiters and source text in user prompt")
+            Issue.record("Expected nonced delimiters and source text in user prompt")
             return
         }
-        #expect(startRange.upperBound <= sourceRange.lowerBound)
-        #expect(sourceRange.upperBound <= endRange.lowerBound)
+        // Same nonce on both fences so the model can pair them.
+        #expect(openMatch.output.1 == closeMatch.output.1)
+        #expect(openMatch.range.upperBound <= sourceRange.lowerBound)
+        #expect(sourceRange.upperBound <= closeMatch.range.lowerBound)
+    }
+
+    @Test func extractionDelimiterNonceIsPerCall() {
+        let schema = JSONSchema.object()
+        let pattern = #/<<<SOURCE ([0-9a-f]{8})>>>/#
+        let first = PromptEngine.buildExtractionPrompt(text: "x", instruction: "Extract.", schema: schema)
+        let second = PromptEngine.buildExtractionPrompt(text: "x", instruction: "Extract.", schema: schema)
+
+        guard
+            let firstNonce = first.user.firstMatch(of: pattern)?.output.1,
+            let secondNonce = second.user.firstMatch(of: pattern)?.output.1
+        else {
+            Issue.record("Expected nonced delimiters in both prompts")
+            return
+        }
+        #expect(firstNonce != secondNonce)
     }
 
     @Test func extractionPromptIncludesInstruction() {

--- a/Tests/CastTests/PromptEngineTests.swift
+++ b/Tests/CastTests/PromptEngineTests.swift
@@ -71,8 +71,9 @@ struct PromptEngineTests {
         )
 
         // Per-call nonce: assert structural shape rather than literal text.
-        let openPattern = #/<<<SOURCE ([0-9a-f]{8})>>>/#
-        let closePattern = #/<<<END SOURCE ([0-9a-f]{8})>>>/#
+        // UUIDs are upper-case hex with hyphens: 8-4-4-4-12.
+        let openPattern = #/<<<SOURCE-([0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12})>>>/#
+        let closePattern = #/<<<END-SOURCE-([0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12})>>>/#
 
         guard
             let openMatch = result.user.firstMatch(of: openPattern),
@@ -90,7 +91,7 @@ struct PromptEngineTests {
 
     @Test func extractionDelimiterNonceIsPerCall() {
         let schema = JSONSchema.object()
-        let pattern = #/<<<SOURCE ([0-9a-f]{8})>>>/#
+        let pattern = #/<<<SOURCE-([0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12})>>>/#
         let first = PromptEngine.buildExtractionPrompt(text: "x", instruction: "Extract.", schema: schema)
         let second = PromptEngine.buildExtractionPrompt(text: "x", instruction: "Extract.", schema: schema)
 

--- a/Tests/CastTests/PromptEngineTests.swift
+++ b/Tests/CastTests/PromptEngineTests.swift
@@ -71,9 +71,11 @@ struct PromptEngineTests {
         )
 
         // Per-call nonce: assert structural shape rather than literal text.
-        // UUIDs are upper-case hex with hyphens: 8-4-4-4-12.
-        let openPattern = #/<<<SOURCE-([0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12})>>>/#
-        let closePattern = #/<<<END-SOURCE-([0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12})>>>/#
+        // UUIDs are hex with hyphens: 8-4-4-4-12. Match case-insensitively
+        // since `UUID().uuidString` casing isn't a documented guarantee.
+        let openPattern = #/<<<SOURCE-([0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12})>>>/#
+        let closePattern =
+            #/<<<END-SOURCE-([0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12})>>>/#
 
         guard
             let openMatch = result.user.firstMatch(of: openPattern),
@@ -91,7 +93,7 @@ struct PromptEngineTests {
 
     @Test func extractionDelimiterNonceIsPerCall() {
         let schema = JSONSchema.object()
-        let pattern = #/<<<SOURCE-([0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12})>>>/#
+        let pattern = #/<<<SOURCE-([0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12})>>>/#
         let first = PromptEngine.buildExtractionPrompt(text: "x", instruction: "Extract.", schema: schema)
         let second = PromptEngine.buildExtractionPrompt(text: "x", instruction: "Extract.", schema: schema)
 


### PR DESCRIPTION
## Summary
- New `extract(from:as:instruction:system:config:didGenerate:)` convenience.
- New `PromptEngine.buildExtractionPrompt` wraps source text in delimiters and emits no-invention guidance.

Closes #36.

## Test plan
- [x] swift build
- [x] swift test --filter PromptEngineTests
- [x] cd Examples && swift build
- [ ] Manual: swift run Extract (local only, requires model)