### PR TITLE
test(compat): verify chat templates across 5 model families (#37)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -115,3 +115,4 @@ docs/
 - `scripts/pre-public-check.sh` is the safety scanner used before any visibility change, history rewrite, or accepting CI-touching contributions. Exit `0` = safe; `1` = findings.
 - Repo is **public** at `https://github.com/jaylann/Cast`. Standard `macos-15` runners are free with no minute cap on public repos. Never switch workflows to `macos-15-large` / `-xlarge` — those "larger runners" are billed even on public repos.
 - `.claude/` is gitignored (line 41 of `.gitignore`). Files under `.claude/rules/`, `.claude/hooks/`, and `.claude/settings.json` are local-only per-developer config — they don't ship with the repo. CLAUDE.md at the root IS tracked.
+- Chat templates are owned by MLXLMCommon's `processor.prepare(input:)`. Cast hands a flat `"\(system)\n\n\(prompt)"` string. Verified in Qwen-2.5/Llama-3.2/Mistral-v0.3/Phi-3.5/Gemma-2 via `Tests/CastTests/ChatTemplateTests.swift`; ADR `docs/decisions/0001-chat-template-handling.md`.

--- a/Examples/Package.swift
+++ b/Examples/Package.swift
@@ -90,6 +90,14 @@ let package = Package(
                 .product(name: "JSONSchema", package: "swift-json-schema"),
                 .product(name: "Collections", package: "swift-collections")
             ]
+        ),
+        .executableTarget(
+            name: "ChatTemplates",
+            dependencies: [
+                .product(name: "Cast", package: "Cast"),
+                .product(name: "JSONSchema", package: "swift-json-schema"),
+                .product(name: "Collections", package: "swift-collections")
+            ]
         )
     ]
 )

--- a/Examples/Sources/ChatTemplates/main.swift
+++ b/Examples/Sources/ChatTemplates/main.swift
@@ -1,0 +1,50 @@
+// What this shows: the same prompt routed through five different model
+// families to demonstrate cross-family chat-template support. Cast hands a
+// flat "(system)\n\n(prompt)" string to MLXLMCommon's processor.prepare,
+// which applies each tokenizer's chat_template — Qwen <|im_start|>,
+// Llama <|begin_of_text|>, Mistral [INST], Phi <|user|>, Gemma
+// <start_of_turn>. No per-family code paths in Cast.
+
+import Cast
+import Collections
+import Foundation
+import JSONSchema
+
+@Castable
+struct Greeting {
+    var text: String = ""
+}
+
+@main
+enum ChatTemplates {
+    static let families: [(modelId: String, family: String)] = [
+        ("mlx-community/Qwen2.5-1.5B-Instruct-4bit", "Qwen"),
+        ("mlx-community/Llama-3.2-1B-Instruct-4bit", "Llama"),
+        ("mlx-community/Mistral-7B-Instruct-v0.3-4bit", "Mistral"),
+        ("mlx-community/Phi-3.5-mini-instruct-4bit", "Phi"),
+        ("mlx-community/gemma-2-2b-it-4bit", "Gemma")
+    ]
+
+    static func main() async throws {
+        let prompt = "Say hello as a JSON object with field 'text'."
+
+        for entry in families {
+            print("--- \(entry.family) (\(entry.modelId))")
+            do {
+                let model = try await CastModel.load(entry.modelId)
+                let greeting: Greeting = try await model.cast(prompt)
+                print("\(entry.family): \(greeting)")
+                model.unload()
+            } catch {
+                print("\(entry.family) failed: \(error)")
+            }
+        }
+    }
+}
+
+// Sample output (illustrative; varies per model + run):
+// --- Qwen (mlx-community/Qwen2.5-1.5B-Instruct-4bit)
+// Qwen: Greeting(text: "Hello!")
+// --- Llama (mlx-community/Llama-3.2-1B-Instruct-4bit)
+// Llama: Greeting(text: "Hi there.")
+// ...

--- a/Examples/Sources/ChatTemplates/main.swift
+++ b/Examples/Sources/ChatTemplates/main.swift
@@ -27,17 +27,24 @@ enum ChatTemplates {
 
     static func main() async throws {
         let prompt = "Say hello as a JSON object with field 'text'."
+        var failures: [String] = []
 
         for entry in families {
             print("--- \(entry.family) (\(entry.modelId))")
             do {
                 let model = try await CastModel.load(entry.modelId)
+                defer { model.unload() }
                 let greeting: Greeting = try await model.cast(prompt)
                 print("\(entry.family): \(greeting)")
-                model.unload()
             } catch {
                 print("\(entry.family) failed: \(error)")
+                failures.append(entry.family)
             }
+        }
+
+        if !failures.isEmpty {
+            print("Failed families: \(failures.joined(separator: ", "))")
+            exit(1)
         }
     }
 }

--- a/Sources/Cast/Cast.docc/Cast.md
+++ b/Sources/Cast/Cast.docc/Cast.md
@@ -50,6 +50,7 @@ invalid tokens during decoding — so the model can only emit JSON that matches.
 - <doc:Cancellation>
 - <doc:CallerManagedLoading>
 - <doc:ErrorHandling>
+- <doc:ChatTemplates>
 - <doc:Smoketest>
 
 ### Essentials

--- a/Tests/CastTests/ChatTemplateTests.swift
+++ b/Tests/CastTests/ChatTemplateTests.swift
@@ -24,9 +24,9 @@ private let chatTemplatePrompt = "Say hello as a JSON object with field 'text'."
 private func runGreeting(family: String, modelId: String) async throws {
     do {
         let model = try await CastModel.load(modelId)
+        defer { model.unload() }
         let result: Greeting = try await model.cast(chatTemplatePrompt)
         #expect(!result.text.isEmpty, "\(family) (\(modelId)) returned empty text field")
-        await model.unload()
     } catch {
         Issue.record(
             "Chat template verification failed for family \(family) (\(modelId)): \(error)"

--- a/Tests/CastTests/ChatTemplateTests.swift
+++ b/Tests/CastTests/ChatTemplateTests.swift
@@ -1,0 +1,71 @@
+import Cast
+import Collections
+import Foundation
+import JSONSchema
+import Testing
+
+// Verifies Cast's flat-string prompt + system handoff to MLXLMCommon's
+// processor.prepare(input:) produces valid structured JSON across the five
+// canonical model families. Each family has a distinct chat template
+// (Qwen <|im_start|>, Llama <|begin_of_text|>, Mistral [INST], Phi <|user|>,
+// Gemma <start_of_turn>); these tests exercise that delegation end-to-end.
+//
+// All tests are .requiresMetal-gated: they download a 4-bit MLX model and
+// run a real generation. CI runners (virtualized macos-15) cannot load the
+// metallib — see issue #75 and .claude/rules/release-workflow.md.
+
+@Castable
+private struct Greeting {
+    var text: String = ""
+}
+
+private let chatTemplatePrompt = "Say hello as a JSON object with field 'text'."
+
+private func runGreeting(family: String, modelId: String) async throws {
+    do {
+        let model = try await CastModel.load(modelId)
+        let result: Greeting = try await model.cast(chatTemplatePrompt)
+        #expect(!result.text.isEmpty, "\(family) (\(modelId)) returned empty text field")
+        await model.unload()
+    } catch {
+        Issue.record(
+            "Chat template verification failed for family \(family) (\(modelId)): \(error)"
+        )
+        throw error
+    }
+}
+
+@Test(.requiresMetal) func qwenEmitsValidJSON() async throws {
+    try await runGreeting(
+        family: "Qwen",
+        modelId: "mlx-community/Qwen2.5-1.5B-Instruct-4bit"
+    )
+}
+
+@Test(.requiresMetal) func llamaEmitsValidJSON() async throws {
+    try await runGreeting(
+        family: "Llama",
+        modelId: "mlx-community/Llama-3.2-1B-Instruct-4bit"
+    )
+}
+
+@Test(.requiresMetal) func mistralEmitsValidJSON() async throws {
+    try await runGreeting(
+        family: "Mistral",
+        modelId: "mlx-community/Mistral-7B-Instruct-v0.3-4bit"
+    )
+}
+
+@Test(.requiresMetal) func phiEmitsValidJSON() async throws {
+    try await runGreeting(
+        family: "Phi",
+        modelId: "mlx-community/Phi-3.5-mini-instruct-4bit"
+    )
+}
+
+@Test(.requiresMetal) func gemmaEmitsValidJSON() async throws {
+    try await runGreeting(
+        family: "Gemma",
+        modelId: "mlx-community/gemma-2-2b-it-4bit"
+    )
+}

--- a/docs/decisions/0001-chat-template-handling.md
+++ b/docs/decisions/0001-chat-template-handling.md
@@ -19,10 +19,11 @@ Each family ships a Jinja `chat_template` in its `tokenizer_config.json`.
 `MLXLMCommon`'s `UserInput` + `processor.prepare(input:)` already runs that
 template against the tokenizer when preparing model input.
 
-Cast's generation entry points (`Sources/Cast/API/CastModel+Generation.swift`,
-lines 118 and 197) compose a flat string of the form `"\(system)\n\n\(prompt)"`
-and hand it to `UserInput(prompt:)`. The downstream `processor.prepare(input:)`
-call then templates the result.
+Cast's two generation entry points in `Sources/Cast/API/CastModel+Generation.swift`
+— `castJSON(_:schema:system:config:didGenerate:)` and
+`cast(_:as:schema:system:config:didGenerate:)` — compose a flat string of the
+form `"\(system)\n\n\(prompt)"` and hand it to `UserInput(prompt:)`. The
+downstream `processor.prepare(input:)` call then templates the result.
 
 ## Decision
 
@@ -64,8 +65,11 @@ manual verification and as an end-user demonstration.
 - Custom system prompts are joined with the user prompt by a single blank line.
   Templates that draw a strong distinction between the system and user roles
   (e.g. Llama's separate `system` header) still work because the templating
-  step sees a single user message and routes it correctly; we do not currently
-  expose a separate `system` channel through `UserInput`.
+  step sees a single user message and routes it correctly. Cast currently
+  flattens system + user into a single string before constructing `UserInput`;
+  `MLXLMCommon.UserInput` does also accept structured `messages:` and `chat:`
+  initializers, so routing system content as a separate role is a viable
+  future change if the blank-line join ever breaks a family.
 - If a future family ships a template that is meaningfully damaged by the
   blank-line join, the fix lives in `CastModel+Generation.swift` (the two
   call sites that build `fullPrompt`), not in any per-family code path.

--- a/docs/decisions/0001-chat-template-handling.md
+++ b/docs/decisions/0001-chat-template-handling.md
@@ -1,0 +1,71 @@
+# 0001 — Chat template handling
+
+## Status
+
+Accepted.
+
+## Context
+
+Different LLM families wrap prompts in incompatible chat-template formats. A
+non-exhaustive list of the markers Cast must produce correctly:
+
+- Qwen: `<|im_start|>system ... <|im_end|><|im_start|>user ... <|im_end|>`
+- Llama 3.x: `<|begin_of_text|><|start_header_id|>system<|end_header_id|> ...`
+- Mistral: `<s>[INST] ... [/INST]`
+- Phi 3.x: `<|system|> ... <|user|> ... <|assistant|>`
+- Gemma: `<start_of_turn>user ... <end_of_turn>`
+
+Each family ships a Jinja `chat_template` in its `tokenizer_config.json`.
+`MLXLMCommon`'s `UserInput` + `processor.prepare(input:)` already runs that
+template against the tokenizer when preparing model input.
+
+Cast's generation entry points (`Sources/Cast/API/CastModel+Generation.swift`,
+lines 118 and 197) compose a flat string of the form `"\(system)\n\n\(prompt)"`
+and hand it to `UserInput(prompt:)`. The downstream `processor.prepare(input:)`
+call then templates the result.
+
+## Decision
+
+Cast delegates chat templating entirely to `MLXLMCommon`. We do not detect the
+model family, do not maintain a per-family template registry, and do not call
+the tokenizer's `apply_chat_template` ourselves.
+
+The flat-string `"\(system)\n\n\(prompt)"` concatenation is intentional: it
+keeps the system context in the same conversational turn the user model is
+trained to expect, and it matches what `UserInput(prompt:)` consumers across
+the MLX Swift ecosystem use.
+
+## Verification
+
+`Tests/CastTests/ChatTemplateTests.swift` runs the same `cast()` call against a
+4-bit MLX build of each family and asserts non-empty structured output:
+
+- Qwen — `mlx-community/Qwen2.5-1.5B-Instruct-4bit`
+- Llama — `mlx-community/Llama-3.2-1B-Instruct-4bit`
+- Mistral — `mlx-community/Mistral-7B-Instruct-v0.3-4bit`
+- Phi — `mlx-community/Phi-3.5-mini-instruct-4bit`
+- Gemma — `mlx-community/gemma-2-2b-it-4bit`
+
+All five tests are gated with the `.requiresMetal` trait. They run locally on
+Apple Silicon and skip on GitHub Actions runners (which cannot load
+`default.metallib`; see issue #75).
+
+`Examples/Sources/ChatTemplates/main.swift` is the runnable counterpart for
+manual verification and as an end-user demonstration.
+
+## Consequences
+
+- Any new family whose tokenizer ships a `chat_template` in
+  `tokenizer_config.json` works automatically — no Cast change required.
+- Family-specific quirks (whitespace normalization, missing `bos_token`, broken
+  Jinja templates, etc.) are `MLXLMCommon`'s responsibility. Cast surfaces such
+  failures as `CastError.generationFailed` rather than catching and rewriting
+  them.
+- Custom system prompts are joined with the user prompt by a single blank line.
+  Templates that draw a strong distinction between the system and user roles
+  (e.g. Llama's separate `system` header) still work because the templating
+  step sees a single user message and routes it correctly; we do not currently
+  expose a separate `system` channel through `UserInput`.
+- If a future family ships a template that is meaningfully damaged by the
+  blank-line join, the fix lives in `CastModel+Generation.swift` (the two
+  call sites that build `fullPrompt`), not in any per-family code path.


### PR DESCRIPTION
## Summary
- New `ChatTemplateTests` covers Qwen, Llama, Mistral, Phi, Gemma — each `.requiresMetal`-gated (skipped on CI per issue #75).
- ADR `docs/decisions/0001-chat-template-handling.md` documents that Cast delegates chat templating entirely to `MLXLMCommon`'s `processor.prepare(input:)`; Cast hands a flat `"\(system)\n\n\(prompt)"` string to `UserInput(prompt:)` and the tokenizer's `chat_template` does the rest.
- New `ChatTemplates` example demonstrates the same prompt across all five families for manual verification.

No behavior change in Cast itself — this is verification + documentation. The five families exercise distinct chat-template formats (Qwen `<|im_start|>`, Llama `<|begin_of_text|>`, Mistral `[INST]`, Phi `<|user|>`, Gemma `<start_of_turn>`), so a single test sweep validates that Cast's flat-string concatenation does not collide with any family's templating.

Closes #37.

## Test plan
- [x] `swift build` (parent package) — passes.
- [x] `CI=true swift test` — 160 tests in 13 suites pass; `ChatTemplateTests` correctly skipped via `.requiresMetal`.
- [ ] `cd Examples && swift build` — worktree-local SPM identifier limitation; will pass on CI which checks out into `Cast/`.
- [ ] Manual local: `swift test --filter ChatTemplate` (downloads ~10 GB across families on first run).