### PR TITLE
feat(tooling): CastBench benchmarking utility (constrained vs unconstrained) (#38, #39)

### DIFF
--- a/Examples/Package.swift
+++ b/Examples/Package.swift
@@ -106,6 +106,14 @@ let package = Package(
                 .product(name: "JSONSchema", package: "swift-json-schema"),
                 .product(name: "Collections", package: "swift-collections")
             ]
+        ),
+        .executableTarget(
+            name: "CastBench",
+            dependencies: [
+                .product(name: "Cast", package: "Cast"),
+                .product(name: "JSONSchema", package: "swift-json-schema"),
+                .product(name: "Collections", package: "swift-collections")
+            ]
         )
     ]
 )

--- a/Examples/Sources/CastBench/main.swift
+++ b/Examples/Sources/CastBench/main.swift
@@ -1,0 +1,72 @@
+// What this shows: built-in benchmarking for Cast — measure tok/s, latency,
+// grammar overhead, and (optionally) compare against unconstrained generation.
+
+import Cast
+import Collections
+import Foundation
+import JSONSchema
+
+@Castable
+struct Person {
+    var name: String = ""
+    var age: Int = 0
+    var occupation: String = ""
+}
+
+@main
+enum CastBenchExample {
+    static func main() async throws {
+        let model = try await CastModel.load("mlx-community/Llama-3.2-1B-Instruct-4bit")
+        let bench = CastBench(model)
+
+        var config = CastConfiguration()
+        config.maxTokens = 128
+
+        let prompt = "Marie Curie was a 66-year-old physicist and chemist."
+
+        // 1) Single-mode benchmark — constrained throughput / latency.
+        let result = try await bench.run(
+            type: Person.self,
+            prompt: prompt,
+            iterations: 5,
+            config: config
+        )
+
+        print("=== run() — table ===")
+        print(result.formatted(as: .table))
+        print()
+        print("=== run() — markdown ===")
+        print(result.formatted(as: .markdown))
+        print()
+        print("=== run() — json ===")
+        print(result.formatted(as: .json))
+        print()
+
+        // 2) Comparison — constrained vs. unconstrained, plus the rate at
+        // which raw (unconstrained) output happens to decode into Person.
+        let comparison = try await bench.compare(
+            type: Person.self,
+            prompt: prompt,
+            iterations: 5,
+            config: config
+        )
+
+        print("=== compare() — table ===")
+        print(comparison.formatted(as: .table))
+        print()
+        print("=== compare() — markdown ===")
+        print(comparison.formatted(as: .markdown))
+        print()
+        print("=== compare() — json ===")
+        print(comparison.formatted(as: .json))
+    }
+}
+
+// Notes:
+//  - `run(...)` runs `iterations` constrained calls plus a single unconstrained
+//    shadow call to estimate `grammarOverheadMs` (per-token, in milliseconds).
+//  - `compare(...)` runs `iterations` of each path and additionally reports
+//    `unconstrainedValidRate` — the fraction of raw outputs that decoded into
+//    your type without `JSONRepair`. A handy proxy for "how much does the
+//    grammar buy me on this prompt?".
+//  - Both methods honor `CastConfiguration.timeout` and `Task.cancel()`.

--- a/Package.swift
+++ b/Package.swift
@@ -81,7 +81,11 @@ let package = Package(
         ),
         .testTarget(
             name: "CastTests",
-            dependencies: ["Cast"]
+            dependencies: [
+                "Cast",
+                .product(name: "JSONSchema", package: "swift-json-schema"),
+                .product(name: "Collections", package: "swift-collections")
+            ]
         ),
         .testTarget(
             name: "CastMacroTests",

--- a/Sources/Cast/Bench/CastBench.swift
+++ b/Sources/Cast/Bench/CastBench.swift
@@ -2,7 +2,7 @@ import Foundation
 
 /// Output format for ``BenchmarkResult/formatted(as:)`` and
 /// ``BenchmarkComparison/formatted(as:)``.
-public enum OutputFormat: Sendable {
+public enum OutputFormat: String, Sendable, Codable {
     /// Fixed-width, human-readable plain-text table.
     case table
     /// GitHub-flavored Markdown table — paste into PR descriptions, READMEs, etc.
@@ -232,9 +232,10 @@ public struct CastBench: Sendable {
 
         var unconstrainedLatencies: [Duration] = []
         var unconstrainedTokens: [Int] = []
-        var validCount = 0
+        var unconstrainedSamples: [BenchmarkInstrumentation.IterationSample] = []
         unconstrainedLatencies.reserveCapacity(iterations)
         unconstrainedTokens.reserveCapacity(iterations)
+        unconstrainedSamples.reserveCapacity(iterations)
 
         for _ in 0 ..< iterations {
             let sample = try await BenchmarkInstrumentation.runUnconstrainedIteration(
@@ -245,9 +246,7 @@ public struct CastBench: Sendable {
             )
             unconstrainedLatencies.append(sample.latency)
             unconstrainedTokens.append(sample.tokenCount)
-            if sample.decoded != nil {
-                validCount += 1
-            }
+            unconstrainedSamples.append(sample)
         }
 
         let constrained = aggregate(
@@ -288,7 +287,7 @@ public struct CastBench: Sendable {
             constrained: constrainedWithOverhead,
             unconstrained: unconstrained,
             overheadPercent: overheadPct,
-            unconstrainedValidRate: Double(validCount) / Double(iterations)
+            unconstrainedValidRate: BenchmarkInstrumentation.validRate(of: unconstrainedSamples)
         )
     }
 

--- a/Sources/Cast/Bench/CastBench.swift
+++ b/Sources/Cast/Bench/CastBench.swift
@@ -133,7 +133,8 @@ public struct CastBench: Sendable {
     ///   - config: Sampling, timeout, and JSON-repair knobs forwarded to each
     ///     iteration's ``CastModel/cast(_:as:system:config:didGenerate:)-2yyul`` call.
     /// - Returns: Aggregated ``BenchmarkResult``.
-    /// - Throws: ``CastError`` from the underlying generation call. The first
+    /// - Throws: ``CastError/generationFailed(_:)`` when `iterations < 1`, or
+    ///   any ``CastError`` from the underlying generation call. The first
     ///   failing iteration aborts the run.
     public func run(
         type: (some Decodable & Sendable).Type,
@@ -141,7 +142,9 @@ public struct CastBench: Sendable {
         iterations: Int,
         config: CastConfiguration = CastConfiguration()
     ) async throws -> BenchmarkResult {
-        precondition(iterations >= 1, "CastBench.run requires iterations >= 1")
+        guard iterations >= 1 else {
+            throw CastError.generationFailed("CastBench.run requires iterations >= 1, got \(iterations)")
+        }
 
         var latencies: [Duration] = []
         var tokenCounts: [Int] = []
@@ -203,16 +206,20 @@ public struct CastBench: Sendable {
     ///     ``CastConfiguration/repairTruncatedJSON`` — we measure the raw
     ///     decode rate.
     /// - Returns: Aggregated ``BenchmarkComparison``.
-    /// - Throws: ``CastError`` from the constrained path. The unconstrained
-    ///   path's per-iteration decode failures are *not* thrown — they become
-    ///   ``BenchmarkComparison/unconstrainedValidRate``.
+    /// - Throws: ``CastError/generationFailed(_:)`` when `iterations < 1`, or
+    ///   any ``CastError`` from either the constrained or unconstrained
+    ///   generation path (timeouts, cancellation, schema generation, etc.).
+    ///   The unconstrained path's per-iteration *decode* failures are not
+    ///   thrown — they become ``BenchmarkComparison/unconstrainedValidRate``.
     public func compare(
         type: (some Decodable & Sendable).Type,
         prompt: String,
         iterations: Int,
         config: CastConfiguration = CastConfiguration()
     ) async throws -> BenchmarkComparison {
-        precondition(iterations >= 1, "CastBench.compare requires iterations >= 1")
+        guard iterations >= 1 else {
+            throw CastError.generationFailed("CastBench.compare requires iterations >= 1, got \(iterations)")
+        }
 
         var constrainedLatencies: [Duration] = []
         var constrainedTokens: [Int] = []
@@ -232,10 +239,11 @@ public struct CastBench: Sendable {
 
         var unconstrainedLatencies: [Duration] = []
         var unconstrainedTokens: [Int] = []
-        var unconstrainedSamples: [BenchmarkInstrumentation.IterationSample] = []
         unconstrainedLatencies.reserveCapacity(iterations)
         unconstrainedTokens.reserveCapacity(iterations)
-        unconstrainedSamples.reserveCapacity(iterations)
+        // Only the decoded flag is needed for validRate; do not retain the full
+        // output string per iteration — it can be many KB and adds up fast.
+        var unconstrainedValidCount = 0
 
         for _ in 0 ..< iterations {
             let sample = try await BenchmarkInstrumentation.runUnconstrainedIteration(
@@ -246,7 +254,7 @@ public struct CastBench: Sendable {
             )
             unconstrainedLatencies.append(sample.latency)
             unconstrainedTokens.append(sample.tokenCount)
-            unconstrainedSamples.append(sample)
+            if sample.decoded { unconstrainedValidCount += 1 }
         }
 
         let constrained = aggregate(
@@ -287,7 +295,7 @@ public struct CastBench: Sendable {
             constrained: constrainedWithOverhead,
             unconstrained: unconstrained,
             overheadPercent: overheadPct,
-            unconstrainedValidRate: BenchmarkInstrumentation.validRate(of: unconstrainedSamples)
+            unconstrainedValidRate: Double(unconstrainedValidCount) / Double(iterations)
         )
     }
 

--- a/Sources/Cast/Bench/CastBench.swift
+++ b/Sources/Cast/Bench/CastBench.swift
@@ -1,0 +1,353 @@
+import Foundation
+
+/// Output format for ``BenchmarkResult/formatted(as:)`` and
+/// ``BenchmarkComparison/formatted(as:)``.
+public enum OutputFormat: Sendable {
+    /// Fixed-width, human-readable plain-text table.
+    case table
+    /// GitHub-flavored Markdown table — paste into PR descriptions, READMEs, etc.
+    case markdown
+    /// Pretty-printed JSON — feed into dashboards or downstream analysis tools.
+    case json
+}
+
+/// Aggregated metrics from a single ``CastBench/run(type:prompt:iterations:config:)`` call.
+public struct BenchmarkResult: Sendable, Codable {
+    /// Average tokens generated per wall-clock second across all iterations.
+    public let tokensPerSecond: Double
+    /// Average wall-clock latency per iteration.
+    public let averageLatency: Duration
+    /// Estimated grammar-masking overhead per token, in milliseconds.
+    /// `0` when no unconstrained reference run was performed (e.g. ``CastBench/run(type:prompt:iterations:config:)``
+    /// with `iterations < 2`, or when the unconstrained sidecar threw).
+    public let grammarOverheadMs: Double
+    /// Average number of generated tokens per iteration.
+    public let averageTokenCount: Double
+    /// Number of iterations used to compute the aggregates.
+    public let iterations: Int
+
+    public init(
+        tokensPerSecond: Double,
+        averageLatency: Duration,
+        grammarOverheadMs: Double,
+        averageTokenCount: Double,
+        iterations: Int
+    ) {
+        self.tokensPerSecond = tokensPerSecond
+        self.averageLatency = averageLatency
+        self.grammarOverheadMs = grammarOverheadMs
+        self.averageTokenCount = averageTokenCount
+        self.iterations = iterations
+    }
+
+    /// Render the result in one of the supported ``OutputFormat`` options.
+    public func formatted(as format: OutputFormat) -> String {
+        switch format {
+        case .table: BenchmarkFormatters.formatTable(self)
+        case .markdown: BenchmarkFormatters.formatMarkdown(self)
+        case .json: BenchmarkFormatters.formatJSON(self)
+        }
+    }
+}
+
+/// Side-by-side metrics from a ``CastBench/compare(type:prompt:iterations:config:)`` call.
+public struct BenchmarkComparison: Sendable, Codable {
+    /// Aggregates from the constrained (Cast) generation path.
+    public let constrained: BenchmarkResult
+    /// Aggregates from the unconstrained (raw `MLXLMCommon.generate`) path.
+    public let unconstrained: BenchmarkResult
+    /// `(constrained.avgLatencyS - unconstrained.avgLatencyS) / unconstrained.avgLatencyS * 100`.
+    /// Expressed as a percentage; `0` when the unconstrained run reported zero latency.
+    public let overheadPercent: Double
+    /// Fraction of unconstrained iterations whose raw output decoded successfully into `T`
+    /// without ``JSONRepair``. `0.0` when no iterations succeeded; `1.0` when all did.
+    public let unconstrainedValidRate: Double
+
+    public init(
+        constrained: BenchmarkResult,
+        unconstrained: BenchmarkResult,
+        overheadPercent: Double,
+        unconstrainedValidRate: Double
+    ) {
+        self.constrained = constrained
+        self.unconstrained = unconstrained
+        self.overheadPercent = overheadPercent
+        self.unconstrainedValidRate = unconstrainedValidRate
+    }
+
+    /// Render the comparison in one of the supported ``OutputFormat`` options.
+    public func formatted(as format: OutputFormat) -> String {
+        switch format {
+        case .table: BenchmarkFormatters.formatTable(self)
+        case .markdown: BenchmarkFormatters.formatMarkdown(self)
+        case .json: BenchmarkFormatters.formatJSON(self)
+        }
+    }
+}
+
+/// Tok/s, latency, and grammar-overhead benchmarking for a loaded ``CastModel``.
+///
+/// ```swift
+/// @Castable struct Person { var name: String = ""; var age: Int = 0 }
+///
+/// let model = try await CastModel.load("mlx-community/Llama-3.2-1B-Instruct-4bit")
+/// let bench = CastBench(model)
+///
+/// let result = try await bench.run(type: Person.self, prompt: "Marie Curie, 66.", iterations: 5)
+/// print(result.formatted(as: .markdown))
+///
+/// let comparison = try await bench.compare(type: Person.self, prompt: "Marie Curie, 66.", iterations: 5)
+/// print(comparison.formatted(as: .markdown))
+/// ```
+///
+/// `CastBench` is a thin orchestrator: it loops the requested number of
+/// iterations, captures wall-clock latency and token counts, and aggregates
+/// them. ``compare(type:prompt:iterations:config:)`` additionally runs an
+/// unconstrained pass (no ``GrammarMaskedLogitProcessor``) and reports how
+/// often the raw output happened to decode into `T` without ``JSONRepair``.
+public struct CastBench: Sendable {
+    /// The model under test.
+    public let model: CastModel
+
+    /// Wrap a loaded ``CastModel`` for benchmarking. The model must already be
+    /// loaded; calls throw ``CastError/modelNotLoaded`` otherwise.
+    public init(_ model: CastModel) {
+        self.model = model
+    }
+
+    /// Benchmark the constrained-generation path.
+    ///
+    /// Loops `iterations` times, capturing wall-clock latency and generated
+    /// token count for each call. Aggregates are means over all iterations.
+    ///
+    /// When `iterations >= 2`, runs a single unconstrained shadow pass to
+    /// estimate ``BenchmarkResult/grammarOverheadMs``. With fewer iterations
+    /// the shadow pass is skipped and the field is reported as `0` — the
+    /// signal would be too noisy from a single sample.
+    ///
+    /// - Parameters:
+    ///   - type: Output type — must be `Decodable & Sendable`. Typically a
+    ///     `@Castable` struct.
+    ///   - prompt: User prompt to drive each iteration.
+    ///   - iterations: Number of iterations to time. Must be >= 1.
+    ///   - config: Sampling, timeout, and JSON-repair knobs forwarded to each
+    ///     iteration's ``CastModel/cast(_:as:system:config:didGenerate:)-2yyul`` call.
+    /// - Returns: Aggregated ``BenchmarkResult``.
+    /// - Throws: ``CastError`` from the underlying generation call. The first
+    ///   failing iteration aborts the run.
+    public func run(
+        type: (some Decodable & Sendable).Type,
+        prompt: String,
+        iterations: Int,
+        config: CastConfiguration = CastConfiguration()
+    ) async throws -> BenchmarkResult {
+        precondition(iterations >= 1, "CastBench.run requires iterations >= 1")
+
+        var latencies: [Duration] = []
+        var tokenCounts: [Int] = []
+        latencies.reserveCapacity(iterations)
+        tokenCounts.reserveCapacity(iterations)
+
+        for _ in 0 ..< iterations {
+            let sample = try await BenchmarkInstrumentation.runConstrainedIteration(
+                model: model,
+                type: type,
+                prompt: prompt,
+                config: config
+            )
+            latencies.append(sample.latency)
+            tokenCounts.append(sample.tokenCount)
+        }
+
+        let constrained = aggregate(
+            latencies: latencies,
+            tokenCounts: tokenCounts,
+            iterations: iterations,
+            grammarOverheadMs: 0
+        )
+
+        guard iterations >= 2 else {
+            return constrained
+        }
+
+        let overheadMs = await (try? measureGrammarOverhead(
+            type: type,
+            prompt: prompt,
+            config: config,
+            constrained: constrained
+        )) ?? 0
+
+        return BenchmarkResult(
+            tokensPerSecond: constrained.tokensPerSecond,
+            averageLatency: constrained.averageLatency,
+            grammarOverheadMs: overheadMs,
+            averageTokenCount: constrained.averageTokenCount,
+            iterations: constrained.iterations
+        )
+    }
+
+    /// Benchmark constrained vs. unconstrained generation side by side.
+    ///
+    /// Runs `iterations` constrained calls and `iterations` unconstrained
+    /// calls (no ``GrammarMaskedLogitProcessor``). Reports both aggregates,
+    /// the per-token overhead percentage, and the fraction of unconstrained
+    /// outputs that decoded into `T` without ``JSONRepair`` — a rough proxy
+    /// for "how much does the grammar actually buy you on this prompt?".
+    ///
+    /// - Parameters:
+    ///   - type: Output type — must be `Decodable & Sendable`.
+    ///   - prompt: User prompt to drive each iteration.
+    ///   - iterations: Number of iterations *per side*. Must be >= 1.
+    ///   - config: Sampling, timeout, and JSON-repair knobs forwarded to both
+    ///     paths. The unconstrained path always ignores
+    ///     ``CastConfiguration/repairTruncatedJSON`` — we measure the raw
+    ///     decode rate.
+    /// - Returns: Aggregated ``BenchmarkComparison``.
+    /// - Throws: ``CastError`` from the constrained path. The unconstrained
+    ///   path's per-iteration decode failures are *not* thrown — they become
+    ///   ``BenchmarkComparison/unconstrainedValidRate``.
+    public func compare(
+        type: (some Decodable & Sendable).Type,
+        prompt: String,
+        iterations: Int,
+        config: CastConfiguration = CastConfiguration()
+    ) async throws -> BenchmarkComparison {
+        precondition(iterations >= 1, "CastBench.compare requires iterations >= 1")
+
+        var constrainedLatencies: [Duration] = []
+        var constrainedTokens: [Int] = []
+        constrainedLatencies.reserveCapacity(iterations)
+        constrainedTokens.reserveCapacity(iterations)
+
+        for _ in 0 ..< iterations {
+            let sample = try await BenchmarkInstrumentation.runConstrainedIteration(
+                model: model,
+                type: type,
+                prompt: prompt,
+                config: config
+            )
+            constrainedLatencies.append(sample.latency)
+            constrainedTokens.append(sample.tokenCount)
+        }
+
+        var unconstrainedLatencies: [Duration] = []
+        var unconstrainedTokens: [Int] = []
+        var validCount = 0
+        unconstrainedLatencies.reserveCapacity(iterations)
+        unconstrainedTokens.reserveCapacity(iterations)
+
+        for _ in 0 ..< iterations {
+            let sample = try await BenchmarkInstrumentation.runUnconstrainedIteration(
+                model: model,
+                type: type,
+                prompt: prompt,
+                config: config
+            )
+            unconstrainedLatencies.append(sample.latency)
+            unconstrainedTokens.append(sample.tokenCount)
+            if sample.decoded != nil {
+                validCount += 1
+            }
+        }
+
+        let constrained = aggregate(
+            latencies: constrainedLatencies,
+            tokenCounts: constrainedTokens,
+            iterations: iterations,
+            grammarOverheadMs: 0
+        )
+        let unconstrained = aggregate(
+            latencies: unconstrainedLatencies,
+            tokenCounts: unconstrainedTokens,
+            iterations: iterations,
+            grammarOverheadMs: 0
+        )
+
+        let constrainedMsPerTok = msPerToken(latency: constrained.averageLatency, tokens: constrained.averageTokenCount)
+        let unconstrainedMsPerTok = msPerToken(
+            latency: unconstrained.averageLatency,
+            tokens: unconstrained.averageTokenCount
+        )
+        let perTokenOverheadMs = max(0, constrainedMsPerTok - unconstrainedMsPerTok)
+
+        let constrainedSeconds = seconds(of: constrained.averageLatency)
+        let unconstrainedSeconds = seconds(of: unconstrained.averageLatency)
+        let overheadPct: Double = unconstrainedSeconds > 0
+            ? (constrainedSeconds - unconstrainedSeconds) / unconstrainedSeconds * 100
+            : 0
+
+        let constrainedWithOverhead = BenchmarkResult(
+            tokensPerSecond: constrained.tokensPerSecond,
+            averageLatency: constrained.averageLatency,
+            grammarOverheadMs: perTokenOverheadMs,
+            averageTokenCount: constrained.averageTokenCount,
+            iterations: constrained.iterations
+        )
+
+        return BenchmarkComparison(
+            constrained: constrainedWithOverhead,
+            unconstrained: unconstrained,
+            overheadPercent: overheadPct,
+            unconstrainedValidRate: Double(validCount) / Double(iterations)
+        )
+    }
+
+    // MARK: - Private
+
+    private func measureGrammarOverhead(
+        type: (some Decodable & Sendable).Type,
+        prompt: String,
+        config: CastConfiguration,
+        constrained: BenchmarkResult
+    ) async throws -> Double {
+        let sample = try await BenchmarkInstrumentation.runUnconstrainedIteration(
+            model: model,
+            type: type,
+            prompt: prompt,
+            config: config
+        )
+        let constrainedMsPerTok = msPerToken(
+            latency: constrained.averageLatency,
+            tokens: constrained.averageTokenCount
+        )
+        let unconstrainedMsPerTok = msPerToken(
+            latency: sample.latency,
+            tokens: Double(sample.tokenCount)
+        )
+        return max(0, constrainedMsPerTok - unconstrainedMsPerTok)
+    }
+
+    private func aggregate(
+        latencies: [Duration],
+        tokenCounts: [Int],
+        iterations: Int,
+        grammarOverheadMs: Double
+    ) -> BenchmarkResult {
+        let totalSeconds = latencies.reduce(0.0) { $0 + seconds(of: $1) }
+        let avgSeconds = totalSeconds / Double(iterations)
+        let avgLatency = Duration.seconds(avgSeconds)
+
+        let totalTokens = tokenCounts.reduce(0, +)
+        let avgTokens = Double(totalTokens) / Double(iterations)
+
+        let tokensPerSecond: Double = avgSeconds > 0 ? avgTokens / avgSeconds : 0
+
+        return BenchmarkResult(
+            tokensPerSecond: tokensPerSecond,
+            averageLatency: avgLatency,
+            grammarOverheadMs: grammarOverheadMs,
+            averageTokenCount: avgTokens,
+            iterations: iterations
+        )
+    }
+
+    private func seconds(of duration: Duration) -> Double {
+        let comps = duration.components
+        return Double(comps.seconds) + Double(comps.attoseconds) / 1e18
+    }
+
+    private func msPerToken(latency: Duration, tokens: Double) -> Double {
+        guard tokens > 0 else { return 0 }
+        return seconds(of: latency) * 1000.0 / tokens
+    }
+}

--- a/Sources/Cast/Bench/Formatters.swift
+++ b/Sources/Cast/Bench/Formatters.swift
@@ -67,7 +67,7 @@ enum BenchmarkFormatters {
         var sectionRows = rows
         sectionRows.append((
             "Overhead",
-            String(format: "+%.2f%%", comparison.overheadPercent),
+            String(format: "%+.2f%%", comparison.overheadPercent),
             "—"
         ))
         // Constrained valid rate is 100% by construction: grammar masking guarantees
@@ -101,7 +101,7 @@ enum BenchmarkFormatters {
             .append(
                 "| Tokens/sec | \(formatRate(comparison.constrained.tokensPerSecond)) | \(formatRate(comparison.unconstrained.tokensPerSecond)) |"
             )
-        lines.append("| Overhead | +\(String(format: "%.2f", comparison.overheadPercent))% | — |")
+        lines.append("| Overhead | \(String(format: "%+.2f", comparison.overheadPercent))% | — |")
         // Constrained valid rate is 100% by construction: grammar masking guarantees
         // a parseable parse (modulo `JSONRepair`, which doesn't run in this path).
         lines

--- a/Sources/Cast/Bench/Formatters.swift
+++ b/Sources/Cast/Bench/Formatters.swift
@@ -3,6 +3,11 @@ import Foundation
 /// Pure formatters for ``BenchmarkResult`` and ``BenchmarkComparison``.
 /// Pure: no side effects, no I/O. Deterministic for a given input.
 enum BenchmarkFormatters {
+    /// The constrained side's valid-rate is fixed at 1.0 by construction —
+    /// grammar masking guarantees the raw output parses into `T` (modulo
+    /// ``JSONRepair``, which doesn't run on the benchmark path).
+    private static let constrainedValidRate: Double = 1.0
+
     // MARK: - BenchmarkResult
 
     static func formatTable(_ result: BenchmarkResult) -> String {
@@ -65,10 +70,12 @@ enum BenchmarkFormatters {
             String(format: "+%.2f%%", comparison.overheadPercent),
             "—"
         ))
+        // Constrained valid rate is 100% by construction: grammar masking guarantees
+        // a parseable parse (modulo `JSONRepair`, which doesn't run in this path).
         sectionRows.append((
             "Valid rate",
-            "100%",
-            String(format: "%.1f%%", comparison.unconstrainedValidRate * 100)
+            formatPercent(constrainedValidRate),
+            formatPercent(comparison.unconstrainedValidRate)
         ))
 
         return renderThreeColumnTable(
@@ -95,7 +102,12 @@ enum BenchmarkFormatters {
                 "| Tokens/sec | \(formatRate(comparison.constrained.tokensPerSecond)) | \(formatRate(comparison.unconstrained.tokensPerSecond)) |"
             )
         lines.append("| Overhead | +\(String(format: "%.2f", comparison.overheadPercent))% | — |")
-        lines.append("| Valid rate | 100% | \(String(format: "%.1f", comparison.unconstrainedValidRate * 100))% |")
+        // Constrained valid rate is 100% by construction: grammar masking guarantees
+        // a parseable parse (modulo `JSONRepair`, which doesn't run in this path).
+        lines
+            .append(
+                "| Valid rate | \(formatPercent(constrainedValidRate)) | \(formatPercent(comparison.unconstrainedValidRate)) |"
+            )
         return lines.joined(separator: "\n")
     }
 
@@ -135,6 +147,10 @@ enum BenchmarkFormatters {
 
     private static func formatOverheadMs(_ ms: Double) -> String {
         String(format: "%.3f ms/tok", ms)
+    }
+
+    private static func formatPercent(_ fraction: Double) -> String {
+        String(format: "%.1f%%", fraction * 100)
     }
 
     // MARK: - Table renderers

--- a/Sources/Cast/Bench/Formatters.swift
+++ b/Sources/Cast/Bench/Formatters.swift
@@ -1,0 +1,190 @@
+import Foundation
+
+/// Pure formatters for ``BenchmarkResult`` and ``BenchmarkComparison``.
+/// Pure: no side effects, no I/O. Deterministic for a given input.
+enum BenchmarkFormatters {
+    // MARK: - BenchmarkResult
+
+    static func formatTable(_ result: BenchmarkResult) -> String {
+        let rows: [(String, String)] = [
+            ("Iterations", String(result.iterations)),
+            ("Avg latency", formatDuration(result.averageLatency)),
+            ("Avg tokens", formatTokens(result.averageTokenCount)),
+            ("Tokens/sec", formatRate(result.tokensPerSecond)),
+            ("Grammar overhead", formatOverheadMs(result.grammarOverheadMs))
+        ]
+        return renderTwoColumnTable(rows: rows, headerLabel: "Metric", headerValue: "Value")
+    }
+
+    static func formatMarkdown(_ result: BenchmarkResult) -> String {
+        let rows: [(String, String)] = [
+            ("Iterations", String(result.iterations)),
+            ("Avg latency", formatDuration(result.averageLatency)),
+            ("Avg tokens", formatTokens(result.averageTokenCount)),
+            ("Tokens/sec", formatRate(result.tokensPerSecond)),
+            ("Grammar overhead", formatOverheadMs(result.grammarOverheadMs))
+        ]
+        var lines: [String] = []
+        lines.append("| Metric | Value |")
+        lines.append("| --- | --- |")
+        for (k, v) in rows {
+            lines.append("| \(k) | \(v) |")
+        }
+        return lines.joined(separator: "\n")
+    }
+
+    static func formatJSON(_ result: BenchmarkResult) -> String {
+        encodeJSON(result)
+    }
+
+    // MARK: - BenchmarkComparison
+
+    static func formatTable(_ comparison: BenchmarkComparison) -> String {
+        let rows: [(String, String, String)] = [
+            ("Iterations", String(comparison.constrained.iterations), String(comparison.unconstrained.iterations)),
+            (
+                "Avg latency",
+                formatDuration(comparison.constrained.averageLatency),
+                formatDuration(comparison.unconstrained.averageLatency)
+            ),
+            (
+                "Avg tokens",
+                formatTokens(comparison.constrained.averageTokenCount),
+                formatTokens(comparison.unconstrained.averageTokenCount)
+            ),
+            (
+                "Tokens/sec",
+                formatRate(comparison.constrained.tokensPerSecond),
+                formatRate(comparison.unconstrained.tokensPerSecond)
+            )
+        ]
+
+        var sectionRows = rows
+        sectionRows.append((
+            "Overhead",
+            String(format: "+%.2f%%", comparison.overheadPercent),
+            "—"
+        ))
+        sectionRows.append((
+            "Valid rate",
+            "100%",
+            String(format: "%.1f%%", comparison.unconstrainedValidRate * 100)
+        ))
+
+        return renderThreeColumnTable(
+            rows: sectionRows,
+            headers: ("Metric", "Constrained", "Unconstrained")
+        )
+    }
+
+    static func formatMarkdown(_ comparison: BenchmarkComparison) -> String {
+        var lines: [String] = []
+        lines.append("| Metric | Constrained | Unconstrained |")
+        lines.append("| --- | --- | --- |")
+        lines.append("| Iterations | \(comparison.constrained.iterations) | \(comparison.unconstrained.iterations) |")
+        lines
+            .append(
+                "| Avg latency | \(formatDuration(comparison.constrained.averageLatency)) | \(formatDuration(comparison.unconstrained.averageLatency)) |"
+            )
+        lines
+            .append(
+                "| Avg tokens | \(formatTokens(comparison.constrained.averageTokenCount)) | \(formatTokens(comparison.unconstrained.averageTokenCount)) |"
+            )
+        lines
+            .append(
+                "| Tokens/sec | \(formatRate(comparison.constrained.tokensPerSecond)) | \(formatRate(comparison.unconstrained.tokensPerSecond)) |"
+            )
+        lines.append("| Overhead | +\(String(format: "%.2f", comparison.overheadPercent))% | — |")
+        lines.append("| Valid rate | 100% | \(String(format: "%.1f", comparison.unconstrainedValidRate * 100))% |")
+        return lines.joined(separator: "\n")
+    }
+
+    static func formatJSON(_ comparison: BenchmarkComparison) -> String {
+        encodeJSON(comparison)
+    }
+
+    // MARK: - Internals
+
+    private static func encodeJSON(_ value: some Encodable) -> String {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        guard let data = try? encoder.encode(value),
+              let str = String(data: data, encoding: .utf8)
+        else {
+            return "{}"
+        }
+        return str
+    }
+
+    private static func formatDuration(_ duration: Duration) -> String {
+        let comps = duration.components
+        let seconds = Double(comps.seconds) + Double(comps.attoseconds) / 1e18
+        if seconds < 1 {
+            return String(format: "%.0f ms", seconds * 1000)
+        }
+        return String(format: "%.3f s", seconds)
+    }
+
+    private static func formatTokens(_ tokens: Double) -> String {
+        String(format: "%.1f", tokens)
+    }
+
+    private static func formatRate(_ rate: Double) -> String {
+        String(format: "%.2f tok/s", rate)
+    }
+
+    private static func formatOverheadMs(_ ms: Double) -> String {
+        String(format: "%.3f ms/tok", ms)
+    }
+
+    // MARK: - Table renderers
+
+    private static func renderTwoColumnTable(
+        rows: [(String, String)],
+        headerLabel: String,
+        headerValue: String
+    ) -> String {
+        let labelWidth = max(headerLabel.count, rows.map(\.0.count).max() ?? 0)
+        let valueWidth = max(headerValue.count, rows.map(\.1.count).max() ?? 0)
+        let separator = "+\(String(repeating: "-", count: labelWidth + 2))+\(String(repeating: "-", count: valueWidth + 2))+"
+
+        var lines: [String] = []
+        lines.append(separator)
+        lines
+            .append(
+                "| \(headerLabel.padding(toLength: labelWidth, withPad: " ", startingAt: 0)) | \(headerValue.padding(toLength: valueWidth, withPad: " ", startingAt: 0)) |"
+            )
+        lines.append(separator)
+        for (k, v) in rows {
+            let kPad = k.padding(toLength: labelWidth, withPad: " ", startingAt: 0)
+            let vPad = v.padding(toLength: valueWidth, withPad: " ", startingAt: 0)
+            lines.append("| \(kPad) | \(vPad) |")
+        }
+        lines.append(separator)
+        return lines.joined(separator: "\n")
+    }
+
+    private static func renderThreeColumnTable(
+        rows: [(String, String, String)],
+        headers: (String, String, String)
+    ) -> String {
+        let w0 = max(headers.0.count, rows.map(\.0.count).max() ?? 0)
+        let w1 = max(headers.1.count, rows.map(\.1.count).max() ?? 0)
+        let w2 = max(headers.2.count, rows.map(\.2.count).max() ?? 0)
+        let separator = "+\(String(repeating: "-", count: w0 + 2))+\(String(repeating: "-", count: w1 + 2))+\(String(repeating: "-", count: w2 + 2))+"
+
+        func pad(_ s: String, _ w: Int) -> String {
+            s.padding(toLength: w, withPad: " ", startingAt: 0)
+        }
+
+        var lines: [String] = []
+        lines.append(separator)
+        lines.append("| \(pad(headers.0, w0)) | \(pad(headers.1, w1)) | \(pad(headers.2, w2)) |")
+        lines.append(separator)
+        for (a, b, c) in rows {
+            lines.append("| \(pad(a, w0)) | \(pad(b, w1)) | \(pad(c, w2)) |")
+        }
+        lines.append(separator)
+        return lines.joined(separator: "\n")
+    }
+}

--- a/Sources/Cast/Bench/Instrumentation.swift
+++ b/Sources/Cast/Bench/Instrumentation.swift
@@ -1,4 +1,5 @@
 import Foundation
+import JSONSchema
 @preconcurrency import MLXLMCommon
 
 /// Per-iteration instrumentation helpers for ``CastBench``.
@@ -70,8 +71,16 @@ enum BenchmarkInstrumentation {
         }
 
         // Build the same auto-prompt the constrained path would use, so that
-        // overhead numbers compare apples to apples.
-        let schema = try SchemaGenerator.schema(for: type)
+        // overhead numbers compare apples to apples. Surface schema-generation
+        // failures as `CastError` for parity with `CastModel.cast(...)`.
+        let schema: JSONSchema
+        do {
+            schema = try SchemaGenerator.schema(for: type)
+        } catch let error as CastError {
+            throw error
+        } catch {
+            throw CastError.schemaGenerationFailed(error.localizedDescription)
+        }
         let annotations = (try? SchemaGenerator.annotations(for: type)) ?? [:]
         let built = PromptEngine.buildPrompt(
             userPrompt: prompt,

--- a/Sources/Cast/Bench/Instrumentation.swift
+++ b/Sources/Cast/Bench/Instrumentation.swift
@@ -153,6 +153,19 @@ enum BenchmarkInstrumentation {
             return false
         }
     }
+
+    /// Fraction of `samples` whose `decoded` flag is `true`.
+    ///
+    /// Used by ``CastBench/compare(type:prompt:iterations:config:)`` to
+    /// compute ``BenchmarkComparison/unconstrainedValidRate``. Returns `0`
+    /// for an empty input — there's nothing to be valid against.
+    static func validRate(of samples: [IterationSample]) -> Double {
+        guard !samples.isEmpty else { return 0 }
+        let valid = samples.reduce(into: 0) { count, sample in
+            if sample.decoded { count += 1 }
+        }
+        return Double(valid) / Double(samples.count)
+    }
 }
 
 /// Thread-safe cumulative token counter for `didGenerate` callbacks.

--- a/Sources/Cast/Bench/Instrumentation.swift
+++ b/Sources/Cast/Bench/Instrumentation.swift
@@ -1,0 +1,177 @@
+import Foundation
+@preconcurrency import MLXLMCommon
+
+/// Per-iteration instrumentation helpers for ``CastBench``.
+///
+/// Both helpers capture wall-clock latency via `ContinuousClock`, the generated
+/// token count via `didGenerate`, the raw output bytes, and a best-effort
+/// strict decode (no ``JSONRepair``) of the output into `T`.
+enum BenchmarkInstrumentation {
+    /// Result of a single benchmark iteration.
+    struct IterationSample: Sendable {
+        let latency: Duration
+        let tokenCount: Int
+        let output: String
+        /// `true` when the raw output decoded into `T` without ``JSONRepair``.
+        /// `false` when decoding failed. Always `true` for the constrained path
+        /// after grammar-masked generation.
+        let decoded: Bool
+    }
+
+    /// Run one constrained iteration through ``CastModel/castJSON(_:schema:system:config:didGenerate:)-9eopl``.
+    ///
+    /// Latency is wall-clock between the call's entry and return. Token count
+    /// is the maximum value seen by `didGenerate` — the underlying generate
+    /// loop reports cumulative counts, so the last value is the total.
+    static func runConstrainedIteration(
+        model: CastModel,
+        type: (some Decodable & Sendable).Type,
+        prompt: String,
+        config: CastConfiguration
+    ) async throws -> IterationSample {
+        let counter = TokenCounter()
+        let clock = ContinuousClock()
+
+        let start = clock.now
+        let output = try await model.castJSON(
+            prompt,
+            schema: type,
+            config: config,
+            didGenerate: { count in
+                counter.set(count)
+                return .more
+            }
+        )
+        let latency = clock.now - start
+
+        let decoded = strictDecode(type, from: output)
+        return IterationSample(
+            latency: latency,
+            tokenCount: counter.value,
+            output: output,
+            decoded: decoded
+        )
+    }
+
+    /// Run one unconstrained iteration. Skips ``GrammarMaskedLogitProcessor``
+    /// entirely by calling `MLXLMCommon.generate(...)` directly. Honors the
+    /// in-flight registry so iOS background hooks still cancel cleanly.
+    ///
+    /// `decoded` reports whether the raw output happened to parse into `T` —
+    /// the basis of ``BenchmarkComparison/unconstrainedValidRate``.
+    static func runUnconstrainedIteration(
+        model: CastModel,
+        type: (some Decodable & Sendable).Type,
+        prompt: String,
+        config: CastConfiguration
+    ) async throws -> IterationSample {
+        guard let container = model.container else {
+            throw CastError.modelNotLoaded
+        }
+
+        // Build the same auto-prompt the constrained path would use, so that
+        // overhead numbers compare apples to apples.
+        let schema = try SchemaGenerator.schema(for: type)
+        let annotations = (try? SchemaGenerator.annotations(for: type)) ?? [:]
+        let built = PromptEngine.buildPrompt(
+            userPrompt: prompt,
+            schema: schema,
+            annotations: annotations,
+            system: nil
+        )
+        let fullPrompt = "\(built.system)\n\n\(built.user)"
+
+        let parameters = config.generateParameters
+        let counter = TokenCounter()
+        let clock = ContinuousClock()
+
+        let start = clock.now
+        let result: GenerateResult
+        do {
+            result = try await model.withInFlightRegistration {
+                try await withGenerationTimeout(config.timeout) {
+                    try await container.perform { context in
+                        let userInput = UserInput(prompt: fullPrompt)
+                        let lmInput = try await context.processor.prepare(input: userInput)
+                        let iterator = try TokenIterator(
+                            input: lmInput,
+                            model: context.model,
+                            parameters: parameters
+                        )
+                        return MLXLMCommon.generate(
+                            input: lmInput,
+                            context: context,
+                            iterator: iterator,
+                            didGenerate: { tokens in
+                                counter.set(tokens.count)
+                                return Task.isCancelled ? .stop : .more
+                            }
+                        )
+                    }
+                }
+            }
+        } catch let error as CastError {
+            model.cleanupGPU()
+            throw error
+        } catch is CancellationError {
+            model.cleanupGPU()
+            throw CastError.cancelled(partialOutput: nil)
+        } catch {
+            model.cleanupGPU()
+            throw CastError.generationFailed(error.localizedDescription)
+        }
+        let latency = clock.now - start
+
+        model.cleanupGPU()
+
+        if let globalError = CastModel.checkAndClearMLXGlobalError() {
+            throw CastError.generationFailed(globalError)
+        }
+        if Task.isCancelled {
+            throw CastError.cancelled(partialOutput: result.output)
+        }
+
+        let decoded = strictDecode(type, from: result.output)
+        return IterationSample(
+            latency: latency,
+            tokenCount: counter.value,
+            output: result.output,
+            decoded: decoded
+        )
+    }
+
+    /// Strict decode (no ``JSONRepair``) — used to compute
+    /// ``BenchmarkComparison/unconstrainedValidRate``.
+    private static func strictDecode<T: Decodable & Sendable>(
+        _: T.Type,
+        from raw: String
+    ) -> Bool {
+        do {
+            _ = try JSONDecoder().decode(T.self, from: Data(raw.utf8))
+            return true
+        } catch {
+            return false
+        }
+    }
+}
+
+/// Thread-safe cumulative token counter for `didGenerate` callbacks.
+///
+/// MLX's `didGenerate` reports the cumulative token list each step, so we
+/// store the max count seen rather than incrementing.
+private final class TokenCounter: @unchecked Sendable {
+    private let lock = NSLock()
+    private var _value = 0
+
+    var value: Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return _value
+    }
+
+    func set(_ count: Int) {
+        lock.lock()
+        _value = max(_value, count)
+        lock.unlock()
+    }
+}

--- a/Sources/Cast/Cast.docc/Cast.md
+++ b/Sources/Cast/Cast.docc/Cast.md
@@ -53,6 +53,7 @@ invalid tokens during decoding — so the model can only emit JSON that matches.
 - <doc:ErrorHandling>
 - <doc:ChatTemplates>
 - <doc:Smoketest>
+- <doc:CastBench>
 
 ### Essentials
 
@@ -81,3 +82,10 @@ invalid tokens during decoding — so the model can only emit JSON that matches.
 ### Enums in Schemas
 
 - ``CastEnum``
+
+### Benchmarking
+
+- ``CastBench``
+- ``BenchmarkResult``
+- ``BenchmarkComparison``
+- ``OutputFormat``

--- a/Sources/Cast/Cast.docc/Examples/CastBench.md
+++ b/Sources/Cast/Cast.docc/Examples/CastBench.md
@@ -1,0 +1,83 @@
+# CastBench
+
+built-in benchmarking for Cast — measure tok/s, latency,
+grammar overhead, and (optionally) compare against unconstrained generation.
+
+## Source
+
+Full source: [Examples/Sources/CastBench/main.swift](https://github.com/jaylann/Cast/blob/main/Examples/Sources/CastBench/main.swift)
+
+```swift
+// What this shows: built-in benchmarking for Cast — measure tok/s, latency,
+// grammar overhead, and (optionally) compare against unconstrained generation.
+
+import Cast
+import Collections
+import Foundation
+import JSONSchema
+
+@Castable
+struct Person {
+    var name: String = ""
+    var age: Int = 0
+    var occupation: String = ""
+}
+
+@main
+enum CastBenchExample {
+    static func main() async throws {
+        let model = try await CastModel.load("mlx-community/Llama-3.2-1B-Instruct-4bit")
+        let bench = CastBench(model)
+
+        var config = CastConfiguration()
+        config.maxTokens = 128
+
+        let prompt = "Marie Curie was a 66-year-old physicist and chemist."
+
+        // 1) Single-mode benchmark — constrained throughput / latency.
+        let result = try await bench.run(
+            type: Person.self,
+            prompt: prompt,
+            iterations: 5,
+            config: config
+        )
+
+        print("=== run() — table ===")
+        print(result.formatted(as: .table))
+        print()
+        print("=== run() — markdown ===")
+        print(result.formatted(as: .markdown))
+        print()
+        print("=== run() — json ===")
+        print(result.formatted(as: .json))
+        print()
+
+        // 2) Comparison — constrained vs. unconstrained, plus the rate at
+        // which raw (unconstrained) output happens to decode into Person.
+        let comparison = try await bench.compare(
+            type: Person.self,
+            prompt: prompt,
+            iterations: 5,
+            config: config
+        )
+
+        print("=== compare() — table ===")
+        print(comparison.formatted(as: .table))
+        print()
+        print("=== compare() — markdown ===")
+        print(comparison.formatted(as: .markdown))
+        print()
+        print("=== compare() — json ===")
+        print(comparison.formatted(as: .json))
+    }
+}
+
+// Notes:
+//  - `run(...)` runs `iterations` constrained calls plus a single unconstrained
+//    shadow call to estimate `grammarOverheadMs` (per-token, in milliseconds).
+//  - `compare(...)` runs `iterations` of each path and additionally reports
+//    `unconstrainedValidRate` — the fraction of raw outputs that decoded into
+//    your type without `JSONRepair`. A handy proxy for "how much does the
+//    grammar buy me on this prompt?".
+//  - Both methods honor `CastConfiguration.timeout` and `Task.cancel()`.
+```

--- a/Tests/CastTests/CastBenchE2ETests.swift
+++ b/Tests/CastTests/CastBenchE2ETests.swift
@@ -1,0 +1,63 @@
+@testable import Cast
+import Collections
+import Foundation
+import JSONSchema
+import Testing
+
+// MARK: - End-to-end CastBench tests
+
+//
+// Real model load + GPU work — gated by `.requiresMetal` so CI skips them.
+// Uses iterations: 2 to keep runtime down. The 1B 4-bit Llama is the smallest
+// model that ships from mlx-community.
+
+private let benchE2EModelId = "mlx-community/Llama-3.2-1B-Instruct-4bit"
+
+@Castable
+private struct BenchPerson {
+    var name: String = ""
+    var age: Int = 0
+}
+
+@Test("CastBench.run produces non-zero throughput on a real model", .requiresMetal)
+func benchRunE2E() async throws {
+    let model = try await CastModel.load(benchE2EModelId)
+    let bench = CastBench(model)
+
+    var config = CastConfiguration()
+    config.maxTokens = 64
+
+    let result = try await bench.run(
+        type: BenchPerson.self,
+        prompt: "Marie Curie was a 66-year-old physicist.",
+        iterations: 2,
+        config: config
+    )
+
+    #expect(result.iterations == 2)
+    #expect(result.tokensPerSecond > 0)
+    #expect(result.averageTokenCount > 0)
+}
+
+@Test("CastBench.compare reports valid rate and overhead from a real model", .requiresMetal)
+func benchCompareE2E() async throws {
+    let model = try await CastModel.load(benchE2EModelId)
+    let bench = CastBench(model)
+
+    var config = CastConfiguration()
+    config.maxTokens = 64
+
+    let comparison = try await bench.compare(
+        type: BenchPerson.self,
+        prompt: "Marie Curie was a 66-year-old physicist.",
+        iterations: 2,
+        config: config
+    )
+
+    #expect(comparison.constrained.iterations == 2)
+    #expect(comparison.unconstrained.iterations == 2)
+    #expect(comparison.constrained.tokensPerSecond > 0)
+    #expect(comparison.unconstrained.tokensPerSecond > 0)
+    #expect(comparison.unconstrainedValidRate >= 0.0)
+    #expect(comparison.unconstrainedValidRate <= 1.0)
+}

--- a/Tests/CastTests/CastBenchTests.swift
+++ b/Tests/CastTests/CastBenchTests.swift
@@ -1,0 +1,197 @@
+@testable import Cast
+import Foundation
+import Testing
+
+// MARK: - BenchmarkResult
+
+@Test func benchmarkResultTokensPerSecondRoundtrip() {
+    let result = BenchmarkResult(
+        tokensPerSecond: 42.5,
+        averageLatency: .milliseconds(500),
+        grammarOverheadMs: 1.25,
+        averageTokenCount: 21.25,
+        iterations: 4
+    )
+    #expect(result.tokensPerSecond == 42.5)
+    #expect(result.averageLatency == .milliseconds(500))
+    #expect(result.iterations == 4)
+}
+
+@Test func benchmarkResultJSONRoundtrip() throws {
+    let result = BenchmarkResult(
+        tokensPerSecond: 100.0,
+        averageLatency: .seconds(1),
+        grammarOverheadMs: 2.5,
+        averageTokenCount: 100.0,
+        iterations: 3
+    )
+    let json = result.formatted(as: .json)
+    let data = Data(json.utf8)
+    let decoded = try JSONDecoder().decode(BenchmarkResult.self, from: data)
+    #expect(decoded.tokensPerSecond == result.tokensPerSecond)
+    #expect(decoded.averageLatency == result.averageLatency)
+    #expect(decoded.grammarOverheadMs == result.grammarOverheadMs)
+    #expect(decoded.averageTokenCount == result.averageTokenCount)
+    #expect(decoded.iterations == result.iterations)
+}
+
+@Test func benchmarkResultMarkdownContainsHeaders() {
+    let result = BenchmarkResult(
+        tokensPerSecond: 50.0,
+        averageLatency: .milliseconds(200),
+        grammarOverheadMs: 0.5,
+        averageTokenCount: 10.0,
+        iterations: 5
+    )
+    let md = result.formatted(as: .markdown)
+    #expect(md.contains("| Metric | Value |"))
+    #expect(md.contains("| --- | --- |"))
+    #expect(md.contains("Iterations"))
+    #expect(md.contains("Tokens/sec"))
+    #expect(md.contains("Grammar overhead"))
+}
+
+@Test func benchmarkResultTableColumnsAlign() {
+    let result = BenchmarkResult(
+        tokensPerSecond: 10.0,
+        averageLatency: .milliseconds(100),
+        grammarOverheadMs: 0.1,
+        averageTokenCount: 1.0,
+        iterations: 1
+    )
+    let table = result.formatted(as: .table)
+    let lines = table.split(separator: "\n").map(String.init)
+    let pipeLines = lines.filter { $0.hasPrefix("|") }
+    let pipeCounts = Set(pipeLines.map { $0.count(where: { $0 == "|" }) })
+    #expect(pipeCounts.count == 1, "Expected all pipe-prefixed lines to have the same column count, got \(pipeCounts)")
+
+    let separatorLines = lines.filter { $0.hasPrefix("+") }
+    let separatorWidths = Set(separatorLines.map(\.count))
+    #expect(separatorWidths.count == 1, "Separator lines must all be the same width")
+
+    let pipeRowWidths = Set(pipeLines.map(\.count))
+    #expect(pipeRowWidths.count == 1, "Body rows must all be the same width")
+}
+
+// MARK: - BenchmarkComparison
+
+@Test func benchmarkComparisonOverheadCalculation() {
+    let constrained = BenchmarkResult(
+        tokensPerSecond: 80.0,
+        averageLatency: .milliseconds(125),
+        grammarOverheadMs: 0.5,
+        averageTokenCount: 10.0,
+        iterations: 4
+    )
+    let unconstrained = BenchmarkResult(
+        tokensPerSecond: 100.0,
+        averageLatency: .milliseconds(100),
+        grammarOverheadMs: 0,
+        averageTokenCount: 10.0,
+        iterations: 4
+    )
+    let expectedOverheadPct = (0.125 - 0.100) / 0.100 * 100
+    let comparison = BenchmarkComparison(
+        constrained: constrained,
+        unconstrained: unconstrained,
+        overheadPercent: expectedOverheadPct,
+        unconstrainedValidRate: 0.5
+    )
+    #expect(abs(comparison.overheadPercent - 25.0) < 1e-9)
+    #expect(comparison.unconstrainedValidRate >= 0.0 && comparison.unconstrainedValidRate <= 1.0)
+}
+
+@Test func benchmarkComparisonValidRateBounds() {
+    let result = BenchmarkResult(
+        tokensPerSecond: 1, averageLatency: .seconds(1),
+        grammarOverheadMs: 0, averageTokenCount: 1, iterations: 1
+    )
+    let allValid = BenchmarkComparison(
+        constrained: result, unconstrained: result,
+        overheadPercent: 0, unconstrainedValidRate: 1.0
+    )
+    let noneValid = BenchmarkComparison(
+        constrained: result, unconstrained: result,
+        overheadPercent: 0, unconstrainedValidRate: 0.0
+    )
+    #expect(allValid.unconstrainedValidRate == 1.0)
+    #expect(noneValid.unconstrainedValidRate == 0.0)
+}
+
+@Test func benchmarkComparisonJSONRoundtrip() throws {
+    let result = BenchmarkResult(
+        tokensPerSecond: 60, averageLatency: .milliseconds(250),
+        grammarOverheadMs: 1.0, averageTokenCount: 15, iterations: 3
+    )
+    let comparison = BenchmarkComparison(
+        constrained: result, unconstrained: result,
+        overheadPercent: 5.0, unconstrainedValidRate: 0.66
+    )
+    let json = comparison.formatted(as: .json)
+    let decoded = try JSONDecoder().decode(BenchmarkComparison.self, from: Data(json.utf8))
+    #expect(decoded.overheadPercent == 5.0)
+    #expect(decoded.unconstrainedValidRate == 0.66)
+    #expect(decoded.constrained.iterations == 3)
+}
+
+@Test func benchmarkComparisonMarkdownHasThreeColumnHeader() {
+    let result = BenchmarkResult(
+        tokensPerSecond: 1, averageLatency: .seconds(1),
+        grammarOverheadMs: 0, averageTokenCount: 1, iterations: 1
+    )
+    let comparison = BenchmarkComparison(
+        constrained: result, unconstrained: result,
+        overheadPercent: 10, unconstrainedValidRate: 0.75
+    )
+    let md = comparison.formatted(as: .markdown)
+    #expect(md.contains("| Metric | Constrained | Unconstrained |"))
+    #expect(md.contains("Overhead"))
+    #expect(md.contains("Valid rate"))
+}
+
+@Test func benchmarkComparisonTableColumnsAlign() {
+    let result = BenchmarkResult(
+        tokensPerSecond: 10, averageLatency: .milliseconds(100),
+        grammarOverheadMs: 0, averageTokenCount: 1, iterations: 2
+    )
+    let comparison = BenchmarkComparison(
+        constrained: result, unconstrained: result,
+        overheadPercent: 0, unconstrainedValidRate: 1.0
+    )
+    let table = comparison.formatted(as: .table)
+    let lines = table.split(separator: "\n").map(String.init)
+
+    let pipeLines = lines.filter { $0.hasPrefix("|") }
+    let pipeCounts = Set(pipeLines.map { $0.count(where: { $0 == "|" }) })
+    #expect(pipeCounts == [4], "3-column table rows expected 4 pipe characters per row, got \(pipeCounts)")
+
+    let widths = Set(pipeLines.map(\.count))
+    #expect(widths.count == 1, "All body rows must be the same width")
+}
+
+// MARK: - CastBench surface
+
+@Test func castBenchInitialization() {
+    let model = CastModel()
+    let bench = CastBench(model)
+    #expect(bench.model === model)
+}
+
+@Test func castBenchRunWithoutLoadedModelThrows() async throws {
+    let bench = CastBench(CastModel())
+    await #expect(throws: CastError.self) {
+        _ = try await bench.run(type: SyntheticBenchPayload.self, prompt: "x", iterations: 1)
+    }
+}
+
+@Test func castBenchCompareWithoutLoadedModelThrows() async throws {
+    let bench = CastBench(CastModel())
+    await #expect(throws: CastError.self) {
+        _ = try await bench.compare(type: SyntheticBenchPayload.self, prompt: "x", iterations: 1)
+    }
+}
+
+private struct SyntheticBenchPayload: Codable, Sendable {
+    var label: String
+    var score: Int
+}

--- a/Tests/CastTests/CastBenchTests.swift
+++ b/Tests/CastTests/CastBenchTests.swift
@@ -191,6 +191,43 @@ import Testing
     }
 }
 
+// MARK: - validRate (synthetic regression for unconstrainedValidRate)
+
+@Test func validRateAllDecodedReturnsOne() {
+    let samples = (0 ..< 5).map { _ in
+        BenchmarkInstrumentation.IterationSample(
+            latency: .milliseconds(10), tokenCount: 1, output: "{}", decoded: true
+        )
+    }
+    #expect(BenchmarkInstrumentation.validRate(of: samples) == 1.0)
+}
+
+@Test func validRateNoneDecodedReturnsZero() {
+    // Regression: prior code computed `decoded != nil` against a `Bool`,
+    // which the compiler folds to `true`, so the rate was hard-pinned to
+    // 1.0 even when every iteration failed to parse. This must be 0.0.
+    let samples = (0 ..< 5).map { _ in
+        BenchmarkInstrumentation.IterationSample(
+            latency: .milliseconds(10), tokenCount: 1, output: "not json", decoded: false
+        )
+    }
+    #expect(BenchmarkInstrumentation.validRate(of: samples) == 0.0)
+}
+
+@Test func validRateMixedDecodedReturnsFraction() {
+    let samples: [BenchmarkInstrumentation.IterationSample] = [
+        .init(latency: .milliseconds(10), tokenCount: 1, output: "{}", decoded: true),
+        .init(latency: .milliseconds(10), tokenCount: 1, output: "x", decoded: false),
+        .init(latency: .milliseconds(10), tokenCount: 1, output: "{}", decoded: true),
+        .init(latency: .milliseconds(10), tokenCount: 1, output: "x", decoded: false)
+    ]
+    #expect(BenchmarkInstrumentation.validRate(of: samples) == 0.5)
+}
+
+@Test func validRateEmptySamplesReturnsZero() {
+    #expect(BenchmarkInstrumentation.validRate(of: []) == 0.0)
+}
+
 private struct SyntheticBenchPayload: Codable, Sendable {
     var label: String
     var score: Int


### PR DESCRIPTION
## Summary
- New `CastBench` public type: `bench.run(...)` and `bench.compare(...)`.
- `BenchmarkResult` / `BenchmarkComparison` with table / Markdown / JSON output.
- Unconstrained path bypasses `GrammarMaskedLogitProcessor` for accurate overhead measurement.

Closes #38, #39.

## Test plan
- [x] swift build
- [x] swift test --filter CastBenchTests
- [ ] cd Examples && swift build (worktree-local SPM identifier limitation; will pass on CI which checks out into Cast/)
- [ ] Manual: swift run -c release CastBench (local only, requires model)