### PR TITLE
feat(api): castStream() — AsyncSequence of PartialResult<T> (#35)

### DIFF
--- a/Examples/Package.swift
+++ b/Examples/Package.swift
@@ -114,6 +114,14 @@ let package = Package(
                 .product(name: "JSONSchema", package: "swift-json-schema"),
                 .product(name: "Collections", package: "swift-collections")
             ]
+        ),
+        .executableTarget(
+            name: "Streaming",
+            dependencies: [
+                .product(name: "Cast", package: "Cast"),
+                .product(name: "JSONSchema", package: "swift-json-schema"),
+                .product(name: "Collections", package: "swift-collections")
+            ]
         )
     ]
 )

--- a/Examples/Sources/Streaming/main.swift
+++ b/Examples/Sources/Streaming/main.swift
@@ -1,0 +1,32 @@
+// What this shows: progressive partial-result yields from castStream(); each
+// field appears as the model fills it in.
+
+import Cast
+import Collections
+import Foundation
+import JSONSchema
+
+@Castable
+struct Recipe {
+    var title: String = ""
+    var prepMinutes: Int = 0
+    var ingredients: [String] = []
+}
+
+@main
+enum Streaming {
+    static func main() async throws {
+        let model = try await CastModel.load("mlx-community/Llama-3.2-3B-Instruct-4bit")
+        let prompt = "Quick weeknight pasta in 20 minutes."
+
+        for try await partial in model.castStream(prompt, as: Recipe.self) {
+            let pct = Int((partial.progress * 100).rounded())
+            print("[\(pct)% — \(partial.tokenCount) tokens]")
+            if let title = partial.value.title { print("  title: \(title)") }
+            if let minutes = partial.value.prepMinutes { print("  prepMinutes: \(minutes)") }
+            if let ingredients = partial.value.ingredients {
+                print("  ingredients: \(ingredients)")
+            }
+        }
+    }
+}

--- a/Sources/Cast/API/CastModel+Generation.swift
+++ b/Sources/Cast/API/CastModel+Generation.swift
@@ -25,6 +25,8 @@ public extension CastModel {
     ///   on `Task.cancel()`, ``CastError/repairFailed(rawOutput:reason:)``
     ///   when partial output cannot be repaired, ``CastError/decodingFailed(rawOutput:error:)``
     ///   when (possibly repaired) JSON does not decode into `T`.
+    /// - SeeAlso: ``CastModel/castStream(_:as:system:config:)`` for the
+    ///   streaming variant that yields ``PartialResult`` snapshots as fields fill in.
     func cast<T: Decodable & Sendable>(
         _ prompt: String,
         as type: T.Type = T.self,

--- a/Sources/Cast/API/CastModel+Stream.swift
+++ b/Sources/Cast/API/CastModel+Stream.swift
@@ -21,14 +21,22 @@ public extension CastModel {
     /// ```
     ///
     /// The stream terminates with ``CastError`` on schema/generation failure,
-    /// honors `Task.cancel()`, and respects ``CastConfiguration/timeout``.
+    /// honors `Task.cancel()` (surfaced as ``CastError/cancelled(partialOutput:)``
+    /// carrying the last decoded snapshot, if any), and respects
+    /// ``CastConfiguration/timeout``.
+    ///
+    /// Buffering uses ``AsyncThrowingStream/Continuation/BufferingPolicy/bufferingNewest(_:)``
+    /// with a small bound: a slow consumer paired with a fast model will see
+    /// the *latest* snapshots, not every intermediate one. Streaming UIs only
+    /// care about the most recent state, so this trades historical fidelity
+    /// for a memory ceiling.
     func castStream<T: Castable>(
         _ prompt: String,
         as type: T.Type = T.self,
         system: String? = nil,
         config: CastConfiguration = CastConfiguration()
     ) -> AsyncThrowingStream<PartialResult<T>, Error> {
-        AsyncThrowingStream { continuation in
+        AsyncThrowingStream(bufferingPolicy: .bufferingNewest(8)) { continuation in
             let task = Task {
                 do {
                     try await runStream(
@@ -88,6 +96,9 @@ public extension CastModel {
         let parameters = config.generateParameters
         let maxTokens = max(config.maxTokens, 1)
 
+        // Cross-isolation handle for the in-flight buffer so the cancellation
+        // catch (outside the perform closure) can recover the partial bytes.
+        let bufferHolder = StreamBufferHolder()
         do {
             try await withInFlightRegistration {
                 try await withGenerationTimeout(config.timeout) {
@@ -104,27 +115,38 @@ public extension CastModel {
 
                         var buffer = ""
                         var lastTokenCount = 0
+                        var lastProgress = 0.0
 
                         for try await chunk in stream {
                             if Task.isCancelled { break }
                             buffer.append(chunk.chunk)
                             lastTokenCount = chunk.totalTokens
+                            bufferHolder.set(buffer)
 
                             if let snapshot = decodePartial(
                                 T.self,
                                 from: buffer,
                                 tokenCount: lastTokenCount,
-                                maxTokens: maxTokens
+                                maxTokens: maxTokens,
+                                minProgress: lastProgress
                             ) {
+                                lastProgress = snapshot.progress
                                 continuation.yield(snapshot)
                             }
                         }
+
+                        // Cancellation must not be reported as a decode/repair
+                        // failure: a half-formed buffer almost always fails
+                        // `yieldTerminal`, masking the real cause. Surface the
+                        // outer `Task.isCancelled` check below instead.
+                        if Task.isCancelled { return }
 
                         try yieldTerminal(
                             T.self,
                             buffer: buffer,
                             tokenCount: lastTokenCount,
                             maxTokens: maxTokens,
+                            minProgress: lastProgress,
                             config: config,
                             continuation: continuation
                         )
@@ -136,7 +158,7 @@ public extension CastModel {
             throw error
         } catch is CancellationError {
             cleanupGPU()
-            throw CastError.cancelled(partialOutput: nil)
+            throw CastError.cancelled(partialOutput: bufferHolder.snapshot())
         } catch {
             cleanupGPU()
             throw CastError.generationFailed(error.localizedDescription)
@@ -149,8 +171,29 @@ public extension CastModel {
         }
 
         if Task.isCancelled {
-            throw CastError.cancelled(partialOutput: nil)
+            throw CastError.cancelled(partialOutput: bufferHolder.snapshot())
         }
+    }
+}
+
+/// Sendable bridge for the in-flight stream buffer. Lets the post-cancel
+/// `catch` block recover the last bytes accumulated inside the perform
+/// closure (which runs on a different actor) so they can ride along on
+/// `CastError.cancelled(partialOutput:)`.
+private final class StreamBufferHolder: @unchecked Sendable {
+    private let lock = NSLock()
+    private var buffer = ""
+
+    func set(_ newValue: String) {
+        lock.lock()
+        defer { lock.unlock() }
+        buffer = newValue
+    }
+
+    func snapshot() -> String? {
+        lock.lock()
+        defer { lock.unlock() }
+        return buffer.isEmpty ? nil : buffer
     }
 }
 
@@ -158,7 +201,8 @@ private func decodePartial<T: Castable>(
     _: T.Type,
     from buffer: String,
     tokenCount: Int,
-    maxTokens: Int
+    maxTokens: Int,
+    minProgress: Double
 ) -> PartialResult<T>? {
     let candidate: String
     switch JSONRepair.repair(buffer) {
@@ -177,7 +221,8 @@ private func decodePartial<T: Castable>(
         return nil
     }
 
-    let progress = min(Double(tokenCount) / Double(maxTokens), 1.0)
+    let raw = min(Double(tokenCount) / Double(maxTokens), 1.0)
+    let progress = max(raw, minProgress)
     return PartialResult<T>(value: value, progress: progress, tokenCount: tokenCount)
 }
 
@@ -186,6 +231,7 @@ private func yieldTerminal<T: Castable>(
     buffer: String,
     tokenCount: Int,
     maxTokens: Int,
+    minProgress: Double,
     config: CastConfiguration,
     continuation: AsyncThrowingStream<PartialResult<T>, Error>.Continuation
 ) throws {
@@ -216,6 +262,7 @@ private func yieldTerminal<T: Castable>(
         )
     }
 
-    let progress = min(Double(tokenCount) / Double(maxTokens), 1.0)
+    let raw = min(Double(tokenCount) / Double(maxTokens), 1.0)
+    let progress = max(raw, minProgress)
     continuation.yield(PartialResult<T>(value: value, progress: progress, tokenCount: tokenCount))
 }

--- a/Sources/Cast/API/CastModel+Stream.swift
+++ b/Sources/Cast/API/CastModel+Stream.swift
@@ -26,17 +26,22 @@ public extension CastModel {
     /// ``CastConfiguration/timeout``.
     ///
     /// Buffering uses ``AsyncThrowingStream/Continuation/BufferingPolicy/bufferingNewest(_:)``
-    /// with a small bound: a slow consumer paired with a fast model will see
-    /// the *latest* snapshots, not every intermediate one. Streaming UIs only
-    /// care about the most recent state, so this trades historical fidelity
-    /// for a memory ceiling.
+    /// with bound `1`: a slow consumer paired with a fast model will see only
+    /// the *most recent* snapshot at any time, not every intermediate one.
+    /// Streaming UIs only care about the latest state, so this trades historical
+    /// fidelity for a fixed memory ceiling. The terminal yield is the final
+    /// write before `.finish()` and is therefore never dropped.
     func castStream<T: Castable>(
         _ prompt: String,
         as type: T.Type = T.self,
         system: String? = nil,
         config: CastConfiguration = CastConfiguration()
     ) -> AsyncThrowingStream<PartialResult<T>, Error> {
-        AsyncThrowingStream(bufferingPolicy: .bufferingNewest(8)) { continuation in
+        // `bufferingNewest(1)` caps memory at one in-flight `PartialResult<T>`:
+        // a slow consumer paired with a fast generation drops stale snapshots
+        // instead of unbounded buffering. The terminal yield is the last write
+        // before `.finish()` and is therefore never dropped.
+        AsyncThrowingStream(bufferingPolicy: .bufferingNewest(1)) { continuation in
             let task = Task {
                 do {
                     try await runStream(

--- a/Sources/Cast/API/CastModel+Stream.swift
+++ b/Sources/Cast/API/CastModel+Stream.swift
@@ -254,12 +254,27 @@ private func yieldTerminal<T: Castable>(
         decodeInput = buffer
     }
 
+    // The terminal yield must guarantee a fully-decoded value, matching
+    // `cast()` semantics. `T.PartiallyGenerated` is all-Optional, so it
+    // would silently accept a buffer with missing required fields (e.g. a
+    // generation that hit `maxTokens` mid-object). Decode `T.self` first to
+    // enforce the schema's required-field contract; only then project to
+    // `PartiallyGenerated` for the consumer-facing type.
+    let data = Data(decodeInput.utf8)
+    let decoder = JSONDecoder()
+
+    do {
+        _ = try decoder.decode(T.self, from: data)
+    } catch {
+        throw CastError.decodingFailed(
+            rawOutput: decodeInput,
+            error: error.localizedDescription
+        )
+    }
+
     let value: T.PartiallyGenerated
     do {
-        value = try JSONDecoder().decode(
-            T.PartiallyGenerated.self,
-            from: Data(decodeInput.utf8)
-        )
+        value = try decoder.decode(T.PartiallyGenerated.self, from: data)
     } catch {
         throw CastError.decodingFailed(
             rawOutput: decodeInput,

--- a/Sources/Cast/API/CastModel+Stream.swift
+++ b/Sources/Cast/API/CastModel+Stream.swift
@@ -1,0 +1,221 @@
+import Foundation
+import JSONSchema
+import MLX
+@preconcurrency import MLXLMCommon
+@preconcurrency import MLXStructured
+
+public extension CastModel {
+    /// Stream `T.PartiallyGenerated` snapshots as the model fills in fields.
+    ///
+    /// Each yielded ``PartialResult`` carries a decoded snapshot, the running
+    /// token count, and a `0...1` `progress` ratio against
+    /// ``CastConfiguration/maxTokens``. Snapshots become available as soon as
+    /// the in-flight bytes can be repaired into valid JSON; very early chunks
+    /// (e.g. just `{`) are dropped silently. The final yield always carries
+    /// the fully-decoded value.
+    ///
+    /// ```swift
+    /// for try await partial in model.castStream("...", as: Recipe.self) {
+    ///     ui.update(partial.value, progress: partial.progress)
+    /// }
+    /// ```
+    ///
+    /// The stream terminates with ``CastError`` on schema/generation failure,
+    /// honors `Task.cancel()`, and respects ``CastConfiguration/timeout``.
+    func castStream<T: Castable>(
+        _ prompt: String,
+        as type: T.Type = T.self,
+        system: String? = nil,
+        config: CastConfiguration = CastConfiguration()
+    ) -> AsyncThrowingStream<PartialResult<T>, Error> {
+        AsyncThrowingStream { continuation in
+            let task = Task {
+                do {
+                    try await runStream(
+                        prompt: prompt,
+                        type: type,
+                        system: system,
+                        config: config,
+                        continuation: continuation
+                    )
+                    continuation.finish()
+                } catch {
+                    continuation.finish(throwing: error)
+                }
+            }
+            continuation.onTermination = { _ in
+                task.cancel()
+            }
+        }
+    }
+
+    private func runStream<T: Castable>(
+        prompt: String,
+        type: T.Type,
+        system: String?,
+        config: CastConfiguration,
+        continuation: AsyncThrowingStream<PartialResult<T>, Error>.Continuation
+    ) async throws {
+        Self.ensureErrorHandler()
+
+        guard let container else {
+            throw CastError.modelNotLoaded
+        }
+
+        let schema: JSONSchema
+        do {
+            schema = try SchemaGenerator.schema(for: type)
+        } catch {
+            throw CastError.schemaGenerationFailed(error.localizedDescription)
+        }
+
+        let annotations = (try? SchemaGenerator.annotations(for: type)) ?? [:]
+        let built = PromptEngine.buildPrompt(
+            userPrompt: prompt,
+            schema: schema,
+            annotations: annotations,
+            system: system
+        )
+
+        let grammar: Grammar
+        do {
+            grammar = try Grammar.schema(schema)
+        } catch {
+            throw CastError.schemaGenerationFailed(error.localizedDescription)
+        }
+
+        let fullPrompt = "\(built.system)\n\n\(built.user)"
+        let parameters = config.generateParameters
+        let maxTokens = max(config.maxTokens, 1)
+
+        do {
+            try await withInFlightRegistration {
+                try await withGenerationTimeout(config.timeout) {
+                    try await container.perform { context in
+                        let userInput = UserInput(prompt: fullPrompt)
+                        let lmInput = try await context.processor.prepare(input: userInput)
+
+                        let stream = try await MLXStructured.generateStream(
+                            input: lmInput,
+                            parameters: parameters,
+                            context: context,
+                            grammar: grammar
+                        )
+
+                        var buffer = ""
+                        var lastTokenCount = 0
+
+                        for try await chunk in stream {
+                            if Task.isCancelled { break }
+                            buffer.append(chunk.chunk)
+                            lastTokenCount = chunk.totalTokens
+
+                            if let snapshot = decodePartial(
+                                T.self,
+                                from: buffer,
+                                tokenCount: lastTokenCount,
+                                maxTokens: maxTokens
+                            ) {
+                                continuation.yield(snapshot)
+                            }
+                        }
+
+                        try yieldTerminal(
+                            T.self,
+                            buffer: buffer,
+                            tokenCount: lastTokenCount,
+                            maxTokens: maxTokens,
+                            config: config,
+                            continuation: continuation
+                        )
+                    }
+                }
+            }
+        } catch let error as CastError {
+            cleanupGPU()
+            throw error
+        } catch is CancellationError {
+            cleanupGPU()
+            throw CastError.cancelled(partialOutput: nil)
+        } catch {
+            cleanupGPU()
+            throw CastError.generationFailed(error.localizedDescription)
+        }
+
+        cleanupGPU()
+
+        if let globalError = Self.checkAndClearMLXGlobalError() {
+            throw CastError.generationFailed(globalError)
+        }
+
+        if Task.isCancelled {
+            throw CastError.cancelled(partialOutput: nil)
+        }
+    }
+}
+
+private func decodePartial<T: Castable>(
+    _: T.Type,
+    from buffer: String,
+    tokenCount: Int,
+    maxTokens: Int
+) -> PartialResult<T>? {
+    let candidate: String
+    switch JSONRepair.repair(buffer) {
+    case let .ok(value):
+        candidate = value
+    case let .repaired(value, _):
+        candidate = value
+    case .unrecoverable:
+        return nil
+    }
+
+    guard let value = try? JSONDecoder().decode(
+        T.PartiallyGenerated.self,
+        from: Data(candidate.utf8)
+    ) else {
+        return nil
+    }
+
+    let progress = min(Double(tokenCount) / Double(maxTokens), 1.0)
+    return PartialResult<T>(value: value, progress: progress, tokenCount: tokenCount)
+}
+
+private func yieldTerminal<T: Castable>(
+    _: T.Type,
+    buffer: String,
+    tokenCount: Int,
+    maxTokens: Int,
+    config: CastConfiguration,
+    continuation: AsyncThrowingStream<PartialResult<T>, Error>.Continuation
+) throws {
+    let decodeInput: String
+    if config.repairTruncatedJSON {
+        switch JSONRepair.repair(buffer) {
+        case let .ok(value):
+            decodeInput = value
+        case let .repaired(value, _):
+            decodeInput = value
+        case let .unrecoverable(reason):
+            throw CastError.repairFailed(rawOutput: buffer, reason: reason)
+        }
+    } else {
+        decodeInput = buffer
+    }
+
+    let value: T.PartiallyGenerated
+    do {
+        value = try JSONDecoder().decode(
+            T.PartiallyGenerated.self,
+            from: Data(decodeInput.utf8)
+        )
+    } catch {
+        throw CastError.decodingFailed(
+            rawOutput: decodeInput,
+            error: error.localizedDescription
+        )
+    }
+
+    let progress = min(Double(tokenCount) / Double(maxTokens), 1.0)
+    continuation.yield(PartialResult<T>(value: value, progress: progress, tokenCount: tokenCount))
+}

--- a/Sources/Cast/API/Castable.swift
+++ b/Sources/Cast/API/Castable.swift
@@ -12,6 +12,23 @@
 ///     @MinCount(1) var ingredients: [String]
 /// }
 /// ```
+///
+/// ## Supported field types
+///
+/// - Primitives: `String`, `Bool`, `Int`/`UInt` and their sized variants,
+///   `Double`, `Float`.
+/// - Arrays of primitives or other `@Castable` types.
+/// - Other `@Castable` types (nested structurally).
+/// - `Optional` of any of the above.
+///
+/// Fields whose declared type is *neither* a known primitive *nor* another
+/// `@Castable` struct (for example `Date`, `URL`, raw enums, custom types)
+/// are projected into the synthesized `PartiallyGenerated` mirror as
+/// `<TypeName>.PartiallyGenerated?`. Compilation will fail with an
+/// "unknown member `PartiallyGenerated`" error unless the type itself
+/// declares one. If you need to embed such a type, wrap it in a tiny
+/// `@Castable` struct with a single field, or pre-convert to a supported
+/// primitive (e.g. ISO-8601 `String` for dates) before generation.
 @attached(
     member,
     names: named(castSchema), named(init), named(PartiallyGenerated)

--- a/Sources/Cast/API/Castable.swift
+++ b/Sources/Cast/API/Castable.swift
@@ -12,6 +12,9 @@
 ///     @MinCount(1) var ingredients: [String]
 /// }
 /// ```
-@attached(member, names: named(castSchema), named(init))
+@attached(
+    member,
+    names: named(castSchema), named(init), named(PartiallyGenerated)
+)
 @attached(extension, conformances: Castable, Decodable)
 public macro Castable() = #externalMacro(module: "CastMacros", type: "CastableMacro")

--- a/Sources/Cast/API/PartialResult.swift
+++ b/Sources/Cast/API/PartialResult.swift
@@ -1,0 +1,22 @@
+import Foundation
+
+/// A snapshot of a still-streaming ``CastModel/castStream(_:as:system:config:)`` call.
+///
+/// `value` is the partially-decoded form of `T` (every field Optional, fields
+/// that haven't been emitted yet are `nil`). `progress` reflects how close the
+/// generation is to its `maxTokens` budget, clamped to `0...1`. `tokenCount`
+/// is the number of tokens produced so far.
+public struct PartialResult<T: Castable>: Sendable {
+    /// Decoded snapshot. Properties not yet emitted are `nil`.
+    public let value: T.PartiallyGenerated
+    /// Tokens consumed divided by ``CastConfiguration/maxTokens``, clamped to `0...1`.
+    public let progress: Double
+    /// Number of tokens generated up to (and including) this snapshot.
+    public let tokenCount: Int
+
+    public init(value: T.PartiallyGenerated, progress: Double, tokenCount: Int) {
+        self.value = value
+        self.progress = progress
+        self.tokenCount = tokenCount
+    }
+}

--- a/Sources/Cast/API/PartialResult.swift
+++ b/Sources/Cast/API/PartialResult.swift
@@ -9,9 +9,13 @@ import Foundation
 public struct PartialResult<T: Castable>: Sendable {
     /// Decoded snapshot. Properties not yet emitted are `nil`.
     public let value: T.PartiallyGenerated
-    /// Tokens consumed divided by ``CastConfiguration/maxTokens``, clamped to `0...1`.
+    /// Tokens consumed divided by ``CastConfiguration/maxTokens``, clamped to `0...1`
+    /// and guaranteed monotonically non-decreasing across the stream.
     public let progress: Double
-    /// Number of tokens generated up to (and including) this snapshot.
+    /// Approximate count of tokens generated up to (and including) this snapshot.
+    /// Best-effort: derived from MLX chunk yields, may be `0` for very early
+    /// snapshots if the underlying transport delivers byte-granular chunks.
+    /// An authoritative count arrives with the terminal snapshot.
     public let tokenCount: Int
 
     public init(value: T.PartiallyGenerated, progress: Double, tokenCount: Int) {

--- a/Sources/Cast/Cast.docc/Cast.md
+++ b/Sources/Cast/Cast.docc/Cast.md
@@ -49,6 +49,7 @@ invalid tokens during decoding — so the model can only emit JSON that matches.
 - <doc:ValidatorAndExcluding>
 - <doc:PrepareWarmup>
 - <doc:Cancellation>
+- <doc:Streaming>
 - <doc:CallerManagedLoading>
 - <doc:ErrorHandling>
 - <doc:ChatTemplates>

--- a/Sources/Cast/Cast.docc/Examples/Streaming.md
+++ b/Sources/Cast/Cast.docc/Examples/Streaming.md
@@ -1,0 +1,54 @@
+# Streaming
+
+Watch fields fill in as the model writes them.
+
+`castStream(_:as:system:config:)` returns an `AsyncThrowingStream` of
+``PartialResult`` values. Each yield carries:
+
+- `value` — a `T.PartiallyGenerated` snapshot (all-Optional mirror of `T`)
+  decoded from the in-flight buffer once it can be repaired into valid JSON.
+- `progress` — monotonic `0...1` ratio against `CastConfiguration.maxTokens`.
+- `tokenCount` — running token count for the generation.
+
+The terminal yield always carries a fully-decoded value (validated against
+`T`'s required fields, not just the Optional mirror), matching the contract
+of `cast()`. The stream honors `Task.cancel()` (surfaced as
+`CastError.cancelled`) and `CastConfiguration.timeout`. Buffering is
+`bufferingNewest(1)` — slow consumers see only the latest snapshot, never an
+unbounded backlog.
+
+## Source
+
+Full source: [Examples/Sources/Streaming/main.swift](https://github.com/jaylann/Cast/blob/main/Examples/Sources/Streaming/main.swift)
+
+```swift
+import Cast
+import Collections
+import Foundation
+import JSONSchema
+
+@Castable
+struct Recipe {
+    var title: String = ""
+    var prepMinutes: Int = 0
+    var ingredients: [String] = []
+}
+
+@main
+enum Streaming {
+    static func main() async throws {
+        let model = try await CastModel.load("mlx-community/Llama-3.2-3B-Instruct-4bit")
+        let prompt = "Quick weeknight pasta in 20 minutes."
+
+        for try await partial in model.castStream(prompt, as: Recipe.self) {
+            let pct = Int((partial.progress * 100).rounded())
+            print("[\(pct)% — \(partial.tokenCount) tokens]")
+            if let title = partial.value.title { print("  title: \(title)") }
+            if let minutes = partial.value.prepMinutes { print("  prepMinutes: \(minutes)") }
+            if let ingredients = partial.value.ingredients {
+                print("  ingredients: \(ingredients)")
+            }
+        }
+    }
+}
+```

--- a/Sources/Cast/Schema/SchemaGenerator.swift
+++ b/Sources/Cast/Schema/SchemaGenerator.swift
@@ -1,6 +1,6 @@
+import Collections
 import Foundation
 import JSONSchema
-import Collections
 
 // MARK: - FieldAnnotation
 
@@ -17,18 +17,26 @@ public struct FieldAnnotation: Sendable {
 // MARK: - Castable
 
 /// Types using Cast property wrappers must conform to Castable.
-/// Requires a no-arg init so constraint values from default initializers are preserved.
-/// The @Castable macro (Phase 2) will synthesize this automatically.
+///
+/// Requires a no-arg init so constraint values from default initializers are
+/// preserved. The `@Castable` macro synthesizes both the init and the nested
+/// ``PartiallyGenerated`` mirror — a struct of the same shape with every
+/// property made `Optional` — used by ``CastModel/castStream(_:as:system:config:)``
+/// to surface in-flight values as the model fills them in.
 public protocol Castable: Decodable, Sendable {
+    /// Mirror of `Self` whose properties are all `Optional`. Defaults to `Self`
+    /// for hand-rolled `Castable` types that don't go through the macro;
+    /// streamed updates of those types are emitted only at the terminal yield.
+    associatedtype PartiallyGenerated: Sendable & Decodable = Self
+
     init()
 }
 
 // MARK: - SchemaGenerator
 
 public enum SchemaGenerator {
-
     private static let lock = NSLock()
-    private static nonisolated(unsafe) var cache: [ObjectIdentifier: CacheEntry] = [:]
+    private nonisolated(unsafe) static var cache: [ObjectIdentifier: CacheEntry] = [:]
 
     private struct CacheEntry: Sendable {
         let schema: JSONSchema
@@ -104,11 +112,9 @@ public enum SchemaGenerator {
                 case "minLength":
                     constraints.minLength = prop.value as? Int
                 case "lowerBound":
-                    if let v = prop.value as? Int { constraints.intMin = v }
-                    else if let v = prop.value as? Double { constraints.doubleMin = v }
+                    if let v = prop.value as? Int { constraints.intMin = v } else if let v = prop.value as? Double { constraints.doubleMin = v }
                 case "upperBound":
-                    if let v = prop.value as? Int { constraints.intMax = v }
-                    else if let v = prop.value as? Double { constraints.doubleMax = v }
+                    if let v = prop.value as? Int { constraints.intMax = v } else if let v = prop.value as? Double { constraints.doubleMax = v }
                 case "maxCount":
                     constraints.maxItems = prop.value as? Int
                 case "minCount":
@@ -200,10 +206,20 @@ public enum SchemaGenerator {
         case .integer:
             return .integer(description: description, minimum: c.intMin, maximum: c.intMax)
         case .number:
-            return .number(description: description, multipleOf: c.multipleOf, minimum: c.doubleMin, maximum: c.doubleMax)
-        case .array(let element):
+            return .number(
+                description: description,
+                multipleOf: c.multipleOf,
+                minimum: c.doubleMin,
+                maximum: c.doubleMax
+            )
+        case let .array(element):
             let itemSchema = baseSchema(for: element)
-            return .array(description: description, items: itemSchema, minItems: c.exactCount ?? c.minItems, maxItems: c.exactCount ?? c.maxItems)
+            return .array(
+                description: description,
+                items: itemSchema,
+                minItems: c.exactCount ?? c.minItems,
+                maxItems: c.exactCount ?? c.maxItems
+            )
         default:
             if let description {
                 return withDescription(kind, description)
@@ -215,27 +231,27 @@ public enum SchemaGenerator {
     /// Create a base schema from SchemaKind with just a description.
     private static func withDescription(_ kind: SchemaKind, _ desc: String) -> JSONSchema {
         switch kind {
-        case .string: return .string(description: desc)
-        case .integer: return .integer(description: desc)
-        case .number: return .number(description: desc)
-        case .boolean: return .boolean(description: desc)
-        case .array(let element):
-            return .array(description: desc, items: baseSchema(for: element))
+        case .string: .string(description: desc)
+        case .integer: .integer(description: desc)
+        case .number: .number(description: desc)
+        case .boolean: .boolean(description: desc)
+        case let .array(element):
+            .array(description: desc, items: baseSchema(for: element))
         case .object, .enumeration:
-            return baseSchema(for: kind)
+            baseSchema(for: kind)
         }
     }
 
     /// Convert a SchemaKind to a basic JSONSchema (no constraints).
     private static func baseSchema(for kind: SchemaKind) -> JSONSchema {
         switch kind {
-        case .string: return .string()
-        case .integer: return .integer()
-        case .number: return .number()
-        case .boolean: return .boolean()
-        case .array(let element): return .array(items: baseSchema(for: element))
-        case .object: return .object()
-        case .enumeration: return .string()
+        case .string: .string()
+        case .integer: .integer()
+        case .number: .number()
+        case .boolean: .boolean()
+        case let .array(element): .array(items: baseSchema(for: element))
+        case .object: .object()
+        case .enumeration: .string()
         }
     }
 }
@@ -259,11 +275,11 @@ private struct FieldConstraints {
 
     var hasConstraints: Bool {
         maxLength != nil || minLength != nil ||
-        intMin != nil || intMax != nil ||
-        doubleMin != nil || doubleMax != nil ||
-        maxItems != nil || minItems != nil ||
-        oneOfValues != nil ||
-        pattern != nil || multipleOf != nil ||
-        exactCount != nil || isNullable
+            intMin != nil || intMax != nil ||
+            doubleMin != nil || doubleMax != nil ||
+            maxItems != nil || minItems != nil ||
+            oneOfValues != nil ||
+            pattern != nil || multipleOf != nil ||
+            exactCount != nil || isNullable
     }
 }

--- a/Sources/CastMacros/CastableDiagnostic.swift
+++ b/Sources/CastMacros/CastableDiagnostic.swift
@@ -1,16 +1,65 @@
 import SwiftDiagnostics
 
-enum CastableDiagnostic: String, DiagnosticMessage {
-    case requiresStruct = "@Castable can only be applied to structs"
-    case rangeOnString = "@CastRange cannot be applied to String properties"
-    case lengthOnNumeric = "@MaxLength/@MinLength can only be applied to String properties"
-    case countOnNonArray = "@MaxCount/@MinCount/@Count can only be applied to Array properties"
-    case invertedRange = "@CastRange lower bound must be less than or equal to upper bound"
-    case conflictingLengths = "@MinLength value must be less than or equal to @MaxLength value"
-    case patternOnNonString = "@Pattern can only be applied to String properties"
-    case precisionOnNonFloat = "@Precision can only be applied to Double or Float properties"
+enum CastableDiagnostic: DiagnosticMessage {
+    case requiresStruct
+    case rangeOnString
+    case lengthOnNumeric
+    case countOnNonArray
+    case invertedRange
+    case conflictingLengths
+    case patternOnNonString
+    case precisionOnNonFloat
+    /// Warns when a field's declared type isn't a known primitive and isn't
+    /// recognizably another `@Castable` struct (Foundation value types like
+    /// `Date`, `URL`, `UUID`, `Data`, `Decimal`). The macro will still project
+    /// it as `<TypeName>.PartiallyGenerated?` in the synthesized mirror; the
+    /// consumer must supply that conformance themselves or wrap the field.
+    case unknownNonPrimitiveType(typeName: String)
 
-    var message: String { rawValue }
-    var diagnosticID: MessageID { MessageID(domain: "CastMacro", id: String(describing: self)) }
-    var severity: DiagnosticSeverity { .error }
+    var message: String {
+        switch self {
+        case .requiresStruct:
+            "@Castable can only be applied to structs"
+        case .rangeOnString:
+            "@CastRange cannot be applied to String properties"
+        case .lengthOnNumeric:
+            "@MaxLength/@MinLength can only be applied to String properties"
+        case .countOnNonArray:
+            "@MaxCount/@MinCount/@Count can only be applied to Array properties"
+        case .invertedRange:
+            "@CastRange lower bound must be less than or equal to upper bound"
+        case .conflictingLengths:
+            "@MinLength value must be less than or equal to @MaxLength value"
+        case .patternOnNonString:
+            "@Pattern can only be applied to String properties"
+        case .precisionOnNonFloat:
+            "@Precision can only be applied to Double or Float properties"
+        case let .unknownNonPrimitiveType(typeName):
+            "'\(typeName)' is not a Cast-supported primitive; the synthesized PartiallyGenerated mirror will project this field as '\(typeName).PartiallyGenerated?' and will fail to compile unless '\(typeName)' is itself @Castable. Consider wrapping it in a small @Castable struct or pre-converting to a primitive (e.g. ISO-8601 String for dates)."
+        }
+    }
+
+    var diagnosticID: MessageID {
+        let id = switch self {
+        case .requiresStruct: "requiresStruct"
+        case .rangeOnString: "rangeOnString"
+        case .lengthOnNumeric: "lengthOnNumeric"
+        case .countOnNonArray: "countOnNonArray"
+        case .invertedRange: "invertedRange"
+        case .conflictingLengths: "conflictingLengths"
+        case .patternOnNonString: "patternOnNonString"
+        case .precisionOnNonFloat: "precisionOnNonFloat"
+        case .unknownNonPrimitiveType: "unknownNonPrimitiveType"
+        }
+        return MessageID(domain: "CastMacro", id: id)
+    }
+
+    var severity: DiagnosticSeverity {
+        switch self {
+        case .unknownNonPrimitiveType:
+            .warning
+        default:
+            .error
+        }
+    }
 }

--- a/Sources/CastMacros/CastableMacro.swift
+++ b/Sources/CastMacros/CastableMacro.swift
@@ -24,7 +24,11 @@ extension CastableMacro: MemberMacro {
         for (diagnostic, propNode) in diagnostics {
             context.diagnose(Diagnostic(node: propNode, message: diagnostic))
         }
-        guard diagnostics.isEmpty else { return [] }
+        // Warnings (e.g. unknown non-primitive field types) inform the user but
+        // must not block expansion — the synthesized members are still useful
+        // and the warning flags the call-site for follow-up.
+        let hasError = diagnostics.contains { $0.0.severity == .error }
+        guard !hasError else { return [] }
 
         let schemaDecl = generateSchemaDecl(properties: properties)
         let initDecl = generateInitDecl(properties: properties)
@@ -162,6 +166,19 @@ private let floatTypes: Set<String> = ["Double", "Float"]
 private let numericTypes: Set<String> = integerTypes.union(floatTypes)
 private let boolTypes: Set<String> = ["Bool"]
 
+/// Foundation value types developers commonly reach for that are *not*
+/// primitives in Cast's model. They will be projected as
+/// `<TypeName>.PartiallyGenerated?` and break compilation unless the
+/// consumer adds that conformance manually. Warn loudly at the call site.
+private let suspectFoundationTypes: Set<String> = [
+    "Date",
+    "URL",
+    "UUID",
+    "Data",
+    "Decimal",
+    "TimeInterval"
+]
+
 private func validateProperties(_ properties: [PropertyInfo]) -> [(CastableDiagnostic, Syntax)] {
     var diagnostics: [(CastableDiagnostic, Syntax)] = []
 
@@ -222,9 +239,26 @@ private func validateProperties(_ properties: [PropertyInfo]) -> [(CastableDiagn
                 diagnostics.append((.conflictingLengths, node))
             }
         }
+
+        if let warning = unknownTypeWarning(for: prop) {
+            diagnostics.append(warning)
+        }
     }
 
     return diagnostics
+}
+
+/// Emit a warning when the field's declared type is a known-suspect Foundation
+/// value type (`Date`, `URL`, `UUID`, …) so the consumer is told *at the call
+/// site* that the synthesized `PartiallyGenerated` will reference
+/// `<TypeName>.PartiallyGenerated`. We deliberately do *not* warn for every
+/// non-primitive (which would flood the build for legitimate nested `@Castable`
+/// structs we can't see from inside the macro) — only for the Foundation types
+/// users most often try first.
+private func unknownTypeWarning(for prop: PropertyInfo) -> (CastableDiagnostic, Syntax)? {
+    let candidate = prop.isArray ? (prop.arrayElementType ?? "") : prop.typeName
+    guard suspectFoundationTypes.contains(candidate) else { return nil }
+    return (.unknownNonPrimitiveType(typeName: candidate), prop.node)
 }
 
 private func parseRangeBounds(_ args: [String]) -> (lower: Double, upper: Double)? {

--- a/Sources/CastMacros/CastableMacro.swift
+++ b/Sources/CastMacros/CastableMacro.swift
@@ -248,6 +248,24 @@ private func validateProperties(_ properties: [PropertyInfo]) -> [(CastableDiagn
     return diagnostics
 }
 
+/// Strip a trailing `?` from a type name. Array element types come through
+/// `parseType` as raw text, so `[String?]` yields `"String?"` for the element
+/// and the downstream lookups (primitive set, partial projection, schema
+/// generation) all need the unwrapped form.
+private func nonOptionalTypeName(_ typeName: String) -> String {
+    let trimmed = typeName.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard trimmed.hasSuffix("?") else { return trimmed }
+    return String(trimmed.dropLast())
+}
+
+/// Drop module / namespace prefixes from a dotted type name so the suspect
+/// Foundation lookup matches `Foundation.Date` and `SwiftFoundation.Date` the
+/// same way it matches a bare `Date`.
+private func baseIdentifier(_ typeName: String) -> String {
+    let trimmed = nonOptionalTypeName(typeName)
+    return trimmed.split(separator: ".").last.map(String.init) ?? trimmed
+}
+
 /// Emit a warning when the field's declared type is a known-suspect Foundation
 /// value type (`Date`, `URL`, `UUID`, …) so the consumer is told *at the call
 /// site* that the synthesized `PartiallyGenerated` will reference
@@ -256,7 +274,8 @@ private func validateProperties(_ properties: [PropertyInfo]) -> [(CastableDiagn
 /// structs we can't see from inside the macro) — only for the Foundation types
 /// users most often try first.
 private func unknownTypeWarning(for prop: PropertyInfo) -> (CastableDiagnostic, Syntax)? {
-    let candidate = prop.isArray ? (prop.arrayElementType ?? "") : prop.typeName
+    let raw = prop.isArray ? (prop.arrayElementType ?? "") : prop.typeName
+    let candidate = baseIdentifier(raw)
     guard suspectFoundationTypes.contains(candidate) else { return nil }
     return (.unknownNonPrimitiveType(typeName: candidate), prop.node)
 }
@@ -325,24 +344,26 @@ private func generateInitDecl(properties _: [PropertyInfo]) -> DeclSyntax {
 /// snapshots have no notion of "required".
 private func partialFieldType(for prop: PropertyInfo) -> String {
     if prop.isArray {
-        let element = prop.arrayElementType ?? "String"
+        let element = nonOptionalTypeName(prop.arrayElementType ?? "String")
         return "[\(partialElementType(element))]?"
     }
     return "\(partialBaseType(prop.typeName))?"
 }
 
 private func partialBaseType(_ typeName: String) -> String {
-    if stringTypes.contains(typeName) || numericTypes.contains(typeName) || boolTypes.contains(typeName) {
-        return typeName
+    let baseTypeName = nonOptionalTypeName(typeName)
+    if stringTypes.contains(baseTypeName) || numericTypes.contains(baseTypeName) || boolTypes.contains(baseTypeName) {
+        return baseTypeName
     }
-    return "\(typeName).PartiallyGenerated"
+    return "\(baseTypeName).PartiallyGenerated"
 }
 
 private func partialElementType(_ typeName: String) -> String {
-    if stringTypes.contains(typeName) || numericTypes.contains(typeName) || boolTypes.contains(typeName) {
-        return typeName
+    let baseTypeName = nonOptionalTypeName(typeName)
+    if stringTypes.contains(baseTypeName) || numericTypes.contains(baseTypeName) || boolTypes.contains(baseTypeName) {
+        return baseTypeName
     }
-    return "\(typeName).PartiallyGenerated"
+    return "\(baseTypeName).PartiallyGenerated"
 }
 
 private func generatePartiallyGeneratedDecl(properties: [PropertyInfo]) -> DeclSyntax {
@@ -417,7 +438,7 @@ private func schemaExpression(for prop: PropertyInfo) -> String {
     }
 
     if prop.isArray {
-        let elementSchema = elementSchemaExpression(prop.arrayElementType ?? "String")
+        let elementSchema = elementSchemaExpression(nonOptionalTypeName(prop.arrayElementType ?? "String"))
         let descPart = descriptionArg.map { "description: \($0), " } ?? ""
         let itemsPart = "items: \(elementSchema)"
         var extras: [String] = []

--- a/Sources/CastMacros/CastableMacro.swift
+++ b/Sources/CastMacros/CastableMacro.swift
@@ -28,8 +28,9 @@ extension CastableMacro: MemberMacro {
 
         let schemaDecl = generateSchemaDecl(properties: properties)
         let initDecl = generateInitDecl(properties: properties)
+        let partialDecl = generatePartiallyGeneratedDecl(properties: properties)
 
-        return [schemaDecl, initDecl]
+        return [schemaDecl, initDecl, partialDecl]
     }
 }
 
@@ -276,6 +277,55 @@ private func generateSchemaDecl(properties: [PropertyInfo]) -> DeclSyntax {
 private func generateInitDecl(properties _: [PropertyInfo]) -> DeclSyntax {
     """
     init() {
+    }
+    """
+}
+
+// MARK: - PartiallyGenerated Synthesis
+
+/// Project a property's type onto its `PartiallyGenerated` form: known
+/// primitives keep their own type, everything else is treated as a nested
+/// `Castable` and routed through `.PartiallyGenerated`. Arrays carry the
+/// projection through to their element type. The whole field is then made
+/// Optional regardless of whether it was Optional originally — partial
+/// snapshots have no notion of "required".
+private func partialFieldType(for prop: PropertyInfo) -> String {
+    if prop.isArray {
+        let element = prop.arrayElementType ?? "String"
+        return "[\(partialElementType(element))]?"
+    }
+    return "\(partialBaseType(prop.typeName))?"
+}
+
+private func partialBaseType(_ typeName: String) -> String {
+    if stringTypes.contains(typeName) || numericTypes.contains(typeName) || boolTypes.contains(typeName) {
+        return typeName
+    }
+    return "\(typeName).PartiallyGenerated"
+}
+
+private func partialElementType(_ typeName: String) -> String {
+    if stringTypes.contains(typeName) || numericTypes.contains(typeName) || boolTypes.contains(typeName) {
+        return typeName
+    }
+    return "\(typeName).PartiallyGenerated"
+}
+
+private func generatePartiallyGeneratedDecl(properties: [PropertyInfo]) -> DeclSyntax {
+    let fields = properties
+        .map { "var \($0.name): \(partialFieldType(for: $0))" }
+        .joined(separator: "\n        ")
+
+    if properties.isEmpty {
+        return """
+        struct PartiallyGenerated: Sendable, Decodable {
+        }
+        """
+    }
+
+    return """
+    struct PartiallyGenerated: Sendable, Decodable {
+        \(raw: fields)
     }
     """
 }

--- a/Sources/MLXStructured/Generate.swift
+++ b/Sources/MLXStructured/Generate.swift
@@ -31,6 +31,11 @@ public func generate(
 /// One incremental yield from ``generateStream(input:parameters:context:grammar:)``.
 public struct GrammarChunk: Sendable {
     public let chunk: String
+    /// Approximate running token count. Derived from chunk arrivals during
+    /// generation (one token per chunk under MLXLMCommon's current pipeline)
+    /// and corrected to the authoritative count once `.info` lands at the
+    /// tail of the stream — that final correction is delivered as an empty
+    /// `chunk: ""` yield so consumers see the accurate total.
     public let totalTokens: Int
 
     public init(chunk: String, totalTokens: Int) {
@@ -42,6 +47,10 @@ public struct GrammarChunk: Sendable {
 /// Drive a constrained generation and stream decoded text chunks as they arrive,
 /// alongside the running token count. The stream finishes when the model stops
 /// (EOS, max tokens, or downstream cancellation of the consuming task).
+///
+/// `GrammarChunk.totalTokens` is approximate during generation (chunk-counted,
+/// not real-token-counted). The final yield carries the authoritative count
+/// from `.info` — typically as an empty `chunk: ""` correction.
 public func generateStream(
     input: LMInput,
     parameters: GenerateParameters = GenerateParameters(),
@@ -75,7 +84,11 @@ public func generateStream(
                     totalTokens += 1
                     continuation.yield(GrammarChunk(chunk: text, totalTokens: totalTokens))
                 case let .info(info):
+                    // `.info` arrives at the tail with the authoritative token
+                    // count. Yield an empty-text correction so consumers see
+                    // the accurate total instead of the chunk-counted estimate.
                     totalTokens = info.generationTokenCount
+                    continuation.yield(GrammarChunk(chunk: "", totalTokens: totalTokens))
                 case .toolCall:
                     continue
                 }

--- a/Sources/MLXStructured/Generate.swift
+++ b/Sources/MLXStructured/Generate.swift
@@ -4,14 +4,15 @@
 //
 //  Created by Ivan Petrukha on 27.09.2025.
 //
+// Modifications: add Grammar-input chunk stream by Justin Lanfermann, 2026
 
 import Foundation
 import JSONSchema
-import MLXLMCommon
 import MLX
+import MLXLMCommon
 
 #if canImport(FoundationModels)
-import FoundationModels
+    import FoundationModels
 #endif
 
 public func generate(
@@ -24,8 +25,67 @@ public func generate(
     let sampler = parameters.sampler()
     let processor = try await GrammarMaskedLogitProcessor.from(configuration: context.configuration, grammar: grammar)
     let iterator = try TokenIterator(input: input, model: context.model, processor: processor, sampler: sampler)
-    let result = generate(input: input, context: context, iterator: iterator, didGenerate: didGenerate)
-    return result
+    return generate(input: input, context: context, iterator: iterator, didGenerate: didGenerate)
+}
+
+/// One incremental yield from ``generateStream(input:parameters:context:grammar:)``.
+public struct GrammarChunk: Sendable {
+    public let chunk: String
+    public let totalTokens: Int
+
+    public init(chunk: String, totalTokens: Int) {
+        self.chunk = chunk
+        self.totalTokens = totalTokens
+    }
+}
+
+/// Drive a constrained generation and stream decoded text chunks as they arrive,
+/// alongside the running token count. The stream finishes when the model stops
+/// (EOS, max tokens, or downstream cancellation of the consuming task).
+public func generateStream(
+    input: LMInput,
+    parameters: GenerateParameters = GenerateParameters(),
+    context: ModelContext,
+    grammar: Grammar
+) async throws -> AsyncThrowingStream<GrammarChunk, Error> {
+    let sampler = parameters.sampler()
+    let processor = try await GrammarMaskedLogitProcessor.from(
+        configuration: context.configuration,
+        grammar: grammar
+    )
+    let iterator = try TokenIterator(
+        input: input,
+        model: context.model,
+        processor: processor,
+        sampler: sampler
+    )
+    let upstream = generate(input: input, context: context, iterator: iterator)
+
+    return AsyncThrowingStream { continuation in
+        let task = Task {
+            var totalTokens = 0
+            for await generation in upstream {
+                if Task.isCancelled { break }
+                switch generation {
+                case let .chunk(text):
+                    // Approximate token count by chunk count — `Generation.chunk`
+                    // is one decoded token's text per yield in MLXLMCommon's
+                    // current pipeline. Exact counts come via `.info` at the
+                    // tail; downstream consumers use this only for `progress`.
+                    totalTokens += 1
+                    continuation.yield(GrammarChunk(chunk: text, totalTokens: totalTokens))
+                case let .info(info):
+                    totalTokens = info.generationTokenCount
+                case .toolCall:
+                    continue
+                }
+            }
+            continuation.finish()
+        }
+        continuation.onTermination = { _ in
+            task.cancel()
+        }
+    }
 }
 
 public func generate<Content: Decodable>(
@@ -33,7 +93,7 @@ public func generate<Content: Decodable>(
     parameters: GenerateParameters = GenerateParameters(),
     context: ModelContext,
     schema: JSONSchema,
-    generating: Content.Type,
+    generating _: Content.Type,
     indent: Int? = nil,
     didGenerate: ([Int]) -> GenerateDisposition = { _ in .more }
 ) async throws -> (GenerateResult, Content) {
@@ -47,56 +107,61 @@ public func generate<Content: Decodable>(
 }
 
 #if compiler(>=6.2)
-@available(macOS 26.0, iOS 26.0, *)
-public func generate<Content: Generable>(
-    input: LMInput,
-    parameters: GenerateParameters = GenerateParameters(),
-    context: ModelContext,
-    generating: Content.Type,
-    indent: Int? = nil,
-    didGenerate: ([Int]) -> GenerateDisposition = { _ in .more }
-) async throws -> (GenerateResult, Content) {
-    let sampler = parameters.sampler()
-    let grammar = try Grammar.generable(Content.self, indent: indent)
-    let processor = try await GrammarMaskedLogitProcessor.from(configuration: context.configuration, grammar: grammar)
-    let iterator = try TokenIterator(input: input, model: context.model, processor: processor, sampler: sampler)
-    let result = generate(input: input, context: context, iterator: iterator, didGenerate: didGenerate)
-    let content = try Content(GeneratedContent(json: result.output))
-    return (result, content)
-}
+    @available(macOS 26.0, iOS 26.0, *)
+    public func generate<Content: Generable>(
+        input: LMInput,
+        parameters: GenerateParameters = GenerateParameters(),
+        context: ModelContext,
+        generating _: Content.Type,
+        indent: Int? = nil,
+        didGenerate: ([Int]) -> GenerateDisposition = { _ in .more }
+    ) async throws -> (GenerateResult, Content) {
+        let sampler = parameters.sampler()
+        let grammar = try Grammar.generable(Content.self, indent: indent)
+        let processor = try await GrammarMaskedLogitProcessor.from(
+            configuration: context.configuration,
+            grammar: grammar
+        )
+        let iterator = try TokenIterator(input: input, model: context.model, processor: processor, sampler: sampler)
+        let result = generate(input: input, context: context, iterator: iterator, didGenerate: didGenerate)
+        let content = try Content(GeneratedContent(json: result.output))
+        return (result, content)
+    }
 
-@available(macOS 26.0, iOS 26.0, *)
-public func generate<Content: Generable>(
-    input: LMInput,
-    parameters: GenerateParameters = GenerateParameters(),
-    context: ModelContext,
-    generating: Content.Type,
-    indent: Int? = nil
-) async throws -> AsyncStream<Content.PartiallyGenerated> {
-    let sampler = parameters.sampler()
-    let grammar = try Grammar.generable(Content.self, indent: indent)
-    let processor = try await GrammarMaskedLogitProcessor.from(configuration: context.configuration, grammar: grammar)
-    let iterator = try TokenIterator(input: input, model: context.model, processor: processor, sampler: sampler)
-    let stream = generate(input: input, context: context, iterator: iterator)
-    return AsyncStream { continuation in
-        
-        let task = Task {
-            var output = ""
-            for await generation in stream {
-                if let chunk = generation.chunk {
-                    output.append(chunk)
-                    let generatedContent = try GeneratedContent(json: output)
-                    let partiallyGenerated = try Content.PartiallyGenerated(generatedContent)
-                    continuation.yield(partiallyGenerated)
+    @available(macOS 26.0, iOS 26.0, *)
+    public func generate<Content: Generable>(
+        input: LMInput,
+        parameters: GenerateParameters = GenerateParameters(),
+        context: ModelContext,
+        generating _: Content.Type,
+        indent: Int? = nil
+    ) async throws -> AsyncStream<Content.PartiallyGenerated> {
+        let sampler = parameters.sampler()
+        let grammar = try Grammar.generable(Content.self, indent: indent)
+        let processor = try await GrammarMaskedLogitProcessor.from(
+            configuration: context.configuration,
+            grammar: grammar
+        )
+        let iterator = try TokenIterator(input: input, model: context.model, processor: processor, sampler: sampler)
+        let stream = generate(input: input, context: context, iterator: iterator)
+        return AsyncStream { continuation in
+            let task = Task {
+                var output = ""
+                for await generation in stream {
+                    if let chunk = generation.chunk {
+                        output.append(chunk)
+                        let generatedContent = try GeneratedContent(json: output)
+                        let partiallyGenerated = try Content.PartiallyGenerated(generatedContent)
+                        continuation.yield(partiallyGenerated)
+                    }
                 }
+
+                continuation.finish()
             }
-            
-            continuation.finish()
-        }
-        
-        continuation.onTermination = { _ in
-            task.cancel()
+
+            continuation.onTermination = { _ in
+                task.cancel()
+            }
         }
     }
-}
 #endif

--- a/Tests/CastMacroTests/CastDiagnosticTests.swift
+++ b/Tests/CastMacroTests/CastDiagnosticTests.swift
@@ -1,11 +1,9 @@
+@testable import CastMacros
 import SwiftSyntaxMacrosTestSupport
 import Testing
 
-@testable import CastMacros
-
 @Suite("CastableMacro Diagnostics")
 struct CastDiagnosticTests {
-
     @Test("@Castable on class emits requiresStruct")
     func requiresStruct() {
         assertMacroExpansion(
@@ -17,7 +15,7 @@ struct CastDiagnosticTests {
             class Bad {}
             """,
             diagnostics: [
-                DiagnosticSpec(message: CastableDiagnostic.requiresStruct.message, line: 1, column: 1),
+                DiagnosticSpec(message: CastableDiagnostic.requiresStruct.message, line: 1, column: 1)
             ],
             macros: testMacros
         )
@@ -38,7 +36,7 @@ struct CastDiagnosticTests {
             }
             """,
             diagnostics: [
-                DiagnosticSpec(message: CastableDiagnostic.rangeOnString.message, line: 3, column: 5),
+                DiagnosticSpec(message: CastableDiagnostic.rangeOnString.message, line: 3, column: 5)
             ],
             macros: testMacros
         )
@@ -59,7 +57,7 @@ struct CastDiagnosticTests {
             }
             """,
             diagnostics: [
-                DiagnosticSpec(message: CastableDiagnostic.lengthOnNumeric.message, line: 3, column: 5),
+                DiagnosticSpec(message: CastableDiagnostic.lengthOnNumeric.message, line: 3, column: 5)
             ],
             macros: testMacros
         )
@@ -80,7 +78,7 @@ struct CastDiagnosticTests {
             }
             """,
             diagnostics: [
-                DiagnosticSpec(message: CastableDiagnostic.countOnNonArray.message, line: 3, column: 5),
+                DiagnosticSpec(message: CastableDiagnostic.countOnNonArray.message, line: 3, column: 5)
             ],
             macros: testMacros
         )
@@ -101,7 +99,7 @@ struct CastDiagnosticTests {
             }
             """,
             diagnostics: [
-                DiagnosticSpec(message: CastableDiagnostic.invertedRange.message, line: 3, column: 5),
+                DiagnosticSpec(message: CastableDiagnostic.invertedRange.message, line: 3, column: 5)
             ],
             macros: testMacros
         )
@@ -122,7 +120,7 @@ struct CastDiagnosticTests {
             }
             """,
             diagnostics: [
-                DiagnosticSpec(message: CastableDiagnostic.conflictingLengths.message, line: 3, column: 21),
+                DiagnosticSpec(message: CastableDiagnostic.conflictingLengths.message, line: 3, column: 21)
             ],
             macros: testMacros
         )
@@ -143,7 +141,7 @@ struct CastDiagnosticTests {
             }
             """,
             diagnostics: [
-                DiagnosticSpec(message: CastableDiagnostic.patternOnNonString.message, line: 3, column: 5),
+                DiagnosticSpec(message: CastableDiagnostic.patternOnNonString.message, line: 3, column: 5)
             ],
             macros: testMacros
         )
@@ -164,7 +162,47 @@ struct CastDiagnosticTests {
             }
             """,
             diagnostics: [
-                DiagnosticSpec(message: CastableDiagnostic.precisionOnNonFloat.message, line: 3, column: 5),
+                DiagnosticSpec(message: CastableDiagnostic.precisionOnNonFloat.message, line: 3, column: 5)
+            ],
+            macros: testMacros
+        )
+    }
+
+    @Test("Foundation Date field emits unknownNonPrimitiveType warning but expansion still succeeds")
+    func unknownFoundationType() {
+        let warning = CastableDiagnostic.unknownNonPrimitiveType(typeName: "Date")
+        assertMacroExpansion(
+            """
+            @Castable
+            struct Event {
+                var when: Date
+            }
+            """,
+            expandedSource: """
+            struct Event {
+                var when: Date
+
+                static let castSchema: JSONSchema = .object(
+                    properties: OrderedDictionary(dictionaryLiteral:
+                        ("when", Date.castSchema)
+                    ),
+                    required: ["when"],
+                    additionalProperties: .boolean(false)
+                )
+
+                init() {
+                }
+
+                struct PartiallyGenerated: Sendable, Decodable {
+                    var when: Date.PartiallyGenerated?
+                }
+            }
+
+            extension Event: Castable, Decodable {
+            }
+            """,
+            diagnostics: [
+                DiagnosticSpec(message: warning.message, line: 3, column: 5, severity: .warning)
             ],
             macros: testMacros
         )

--- a/Tests/CastMacroTests/PartiallyGeneratedTests.swift
+++ b/Tests/CastMacroTests/PartiallyGeneratedTests.swift
@@ -1,0 +1,227 @@
+@testable import CastMacros
+import SwiftSyntaxMacros
+import SwiftSyntaxMacrosTestSupport
+import Testing
+
+@Suite("CastableMacro PartiallyGenerated Synthesis")
+struct PartiallyGeneratedExpansionTests {
+    @Test("simple struct synthesizes Optional mirror")
+    func simpleStruct() {
+        assertMacroExpansion(
+            """
+            @Castable
+            struct Foo {
+                var a: String = ""
+                var b: Int = 0
+            }
+            """,
+            expandedSource: """
+            struct Foo {
+                var a: String = ""
+                var b: Int = 0
+
+                static let castSchema: JSONSchema = .object(
+                    properties: OrderedDictionary(dictionaryLiteral:
+                        ("a", .string()),
+                        ("b", .integer())
+                    ),
+                    required: ["a", "b"],
+                    additionalProperties: .boolean(false)
+                )
+
+                init() {
+                }
+
+                struct PartiallyGenerated: Sendable, Decodable {
+                    var a: String?
+                    var b: Int?
+                }
+            }
+
+            extension Foo: Castable, Decodable {
+            }
+            """,
+            macros: testMacros
+        )
+    }
+
+    @Test("MaxLength wrapper decays to underlying String?")
+    func maxLengthDecays() {
+        assertMacroExpansion(
+            """
+            @Castable
+            struct Foo {
+                @MaxLength(80) var title: String = ""
+            }
+            """,
+            expandedSource: """
+            struct Foo {
+                @MaxLength(80) var title: String = ""
+
+                static let castSchema: JSONSchema = .object(
+                    properties: OrderedDictionary(dictionaryLiteral:
+                        ("title", .string(maxLength: 80))
+                    ),
+                    required: ["title"],
+                    additionalProperties: .boolean(false)
+                )
+
+                init() {
+                }
+
+                struct PartiallyGenerated: Sendable, Decodable {
+                    var title: String?
+                }
+            }
+
+            extension Foo: Castable, Decodable {
+            }
+            """,
+            macros: testMacros
+        )
+    }
+
+    @Test("CastRange wrapper decays to underlying Int?")
+    func castRangeDecays() {
+        assertMacroExpansion(
+            """
+            @Castable
+            struct Foo {
+                @CastRange(1...10) var rating: Int = 0
+            }
+            """,
+            expandedSource: """
+            struct Foo {
+                @CastRange(1...10) var rating: Int = 0
+
+                static let castSchema: JSONSchema = .object(
+                    properties: OrderedDictionary(dictionaryLiteral:
+                        ("rating", .integer(minimum: 1, maximum: 10))
+                    ),
+                    required: ["rating"],
+                    additionalProperties: .boolean(false)
+                )
+
+                init() {
+                }
+
+                struct PartiallyGenerated: Sendable, Decodable {
+                    var rating: Int?
+                }
+            }
+
+            extension Foo: Castable, Decodable {
+            }
+            """,
+            macros: testMacros
+        )
+    }
+
+    @Test("nested @Castable type recurses to inner PartiallyGenerated")
+    func nestedCastable() {
+        assertMacroExpansion(
+            """
+            @Castable
+            struct Outer {
+                var inner: Inner = .init()
+            }
+            """,
+            expandedSource: """
+            struct Outer {
+                var inner: Inner = .init()
+
+                static let castSchema: JSONSchema = .object(
+                    properties: OrderedDictionary(dictionaryLiteral:
+                        ("inner", Inner.castSchema)
+                    ),
+                    required: ["inner"],
+                    additionalProperties: .boolean(false)
+                )
+
+                init() {
+                }
+
+                struct PartiallyGenerated: Sendable, Decodable {
+                    var inner: Inner.PartiallyGenerated?
+                }
+            }
+
+            extension Outer: Castable, Decodable {
+            }
+            """,
+            macros: testMacros
+        )
+    }
+
+    @Test("primitive array stays primitive in partial")
+    func primitiveArray() {
+        assertMacroExpansion(
+            """
+            @Castable
+            struct Foo {
+                var tags: [String] = []
+            }
+            """,
+            expandedSource: """
+            struct Foo {
+                var tags: [String] = []
+
+                static let castSchema: JSONSchema = .object(
+                    properties: OrderedDictionary(dictionaryLiteral:
+                        ("tags", .array(items: .string()))
+                    ),
+                    required: ["tags"],
+                    additionalProperties: .boolean(false)
+                )
+
+                init() {
+                }
+
+                struct PartiallyGenerated: Sendable, Decodable {
+                    var tags: [String]?
+                }
+            }
+
+            extension Foo: Castable, Decodable {
+            }
+            """,
+            macros: testMacros
+        )
+    }
+
+    @Test("array of nested @Castable recurses through element")
+    func nestedArray() {
+        assertMacroExpansion(
+            """
+            @Castable
+            struct Doc {
+                var sections: [Section] = []
+            }
+            """,
+            expandedSource: """
+            struct Doc {
+                var sections: [Section] = []
+
+                static let castSchema: JSONSchema = .object(
+                    properties: OrderedDictionary(dictionaryLiteral:
+                        ("sections", .array(items: Section.castSchema))
+                    ),
+                    required: ["sections"],
+                    additionalProperties: .boolean(false)
+                )
+
+                init() {
+                }
+
+                struct PartiallyGenerated: Sendable, Decodable {
+                    var sections: [Section.PartiallyGenerated]?
+                }
+            }
+
+            extension Doc: Castable, Decodable {
+            }
+            """,
+            macros: testMacros
+        )
+    }
+}

--- a/Tests/CastMacroTests/PartiallyGeneratedTests.swift
+++ b/Tests/CastMacroTests/PartiallyGeneratedTests.swift
@@ -264,4 +264,43 @@ struct PartiallyGeneratedExpansionTests {
             macros: testMacros
         )
     }
+
+    @Test("array of optional primitive unwraps element type")
+    func arrayOfOptionalPrimitive() {
+        // `[String?]` must not double-wrap into `[String??]` or
+        // `[String?.PartiallyGenerated]?` — the element's trailing `?`
+        // is dropped before the partial-projection lookup.
+        assertMacroExpansion(
+            """
+            @Castable
+            struct Foo {
+                var tags: [String?] = []
+            }
+            """,
+            expandedSource: """
+            struct Foo {
+                var tags: [String?] = []
+
+                static let castSchema: JSONSchema = .object(
+                    properties: OrderedDictionary(dictionaryLiteral:
+                        ("tags", .array(items: .string()))
+                    ),
+                    required: ["tags"],
+                    additionalProperties: .boolean(false)
+                )
+
+                init() {
+                }
+
+                struct PartiallyGenerated: Sendable, Decodable {
+                    var tags: [String]?
+                }
+            }
+
+            extension Foo: Castable, Decodable {
+            }
+            """,
+            macros: testMacros
+        )
+    }
 }

--- a/Tests/CastMacroTests/PartiallyGeneratedTests.swift
+++ b/Tests/CastMacroTests/PartiallyGeneratedTests.swift
@@ -189,6 +189,46 @@ struct PartiallyGeneratedExpansionTests {
         )
     }
 
+    @Test("Optional source field stays single-Optional in the partial mirror")
+    func optionalFields() {
+        assertMacroExpansion(
+            """
+            @Castable
+            struct Foo {
+                var nickname: String?
+                var nested: Inner?
+            }
+            """,
+            expandedSource: """
+            struct Foo {
+                var nickname: String?
+                var nested: Inner?
+
+                static let castSchema: JSONSchema = .object(
+                    properties: OrderedDictionary(dictionaryLiteral:
+                        ("nickname", .string()),
+                        ("nested", Inner.castSchema)
+                    ),
+                    required: nil,
+                    additionalProperties: .boolean(false)
+                )
+
+                init() {
+                }
+
+                struct PartiallyGenerated: Sendable, Decodable {
+                    var nickname: String?
+                    var nested: Inner.PartiallyGenerated?
+                }
+            }
+
+            extension Foo: Castable, Decodable {
+            }
+            """,
+            macros: testMacros
+        )
+    }
+
     @Test("array of nested @Castable recurses through element")
     func nestedArray() {
         assertMacroExpansion(

--- a/Tests/CastTests/CastStreamTests.swift
+++ b/Tests/CastTests/CastStreamTests.swift
@@ -1,0 +1,37 @@
+@testable import Cast
+import Collections
+import Foundation
+import JSONSchema
+import Testing
+
+@Castable
+private struct StreamMovie {
+    var title: String = ""
+    var year: Int = 0
+}
+
+@Test("castStream yields monotonic progress and a terminal full value", .requiresMetal)
+func castStreamProducesPartialsAndTerminal() async throws {
+    let model = try await CastModel.load("mlx-community/Llama-3.2-3B-Instruct-4bit")
+    let prompt = "Inception is a 2010 sci-fi film."
+
+    var snapshots: [PartialResult<StreamMovie>] = []
+    for try await partial in model.castStream(prompt, as: StreamMovie.self) {
+        snapshots.append(partial)
+    }
+
+    #expect(snapshots.count >= 2, "expected at least one partial yield before the terminal one")
+
+    let progress = snapshots.map(\.progress)
+    for window in zip(progress, progress.dropFirst()) {
+        #expect(window.0 <= window.1, "progress must be non-decreasing")
+    }
+
+    let final = try #require(snapshots.last)
+    #expect(final.value.title != nil)
+    #expect(final.value.year != nil)
+
+    let direct: StreamMovie = try await model.cast(prompt, as: StreamMovie.self)
+    #expect(final.value.title == direct.title)
+    #expect(final.value.year == direct.year)
+}

--- a/Tests/CastTests/PartialResultDecodeTests.swift
+++ b/Tests/CastTests/PartialResultDecodeTests.swift
@@ -1,0 +1,85 @@
+@testable import Cast
+import Foundation
+import Testing
+
+/// Local mirror of what the @Castable macro would synthesize for
+/// `struct Movie { var title: String; var year: Int }`. Re-implementing here
+/// avoids a runtime dependency on the macro from this test file (the macro
+/// has its own expansion suite).
+private struct Movie: Castable {
+    var title: String = ""
+    var year: Int = 0
+
+    struct PartiallyGenerated: Sendable, Decodable {
+        var title: String?
+        var year: Int?
+    }
+}
+
+/// Walk progressive byte fragments of a target JSON document through
+/// `JSONRepair` + `Movie.PartiallyGenerated`, asserting each prefix either
+/// produces a partial value or returns nil — never throws.
+@Test func partialDecodeFromProgressiveFragments() {
+    let fragments = [
+        "{",
+        "{\"ti",
+        "{\"title\":\"Incept",
+        "{\"title\":\"Inception\"",
+        "{\"title\":\"Inception\",\"ye",
+        "{\"title\":\"Inception\",\"year\":2010}"
+    ]
+
+    var decodedTitleAt: Int?
+    var decodedYearAt: Int?
+
+    for (idx, fragment) in fragments.enumerated() {
+        let value = decodePartial(Movie.self, from: fragment)
+        if let value, value.title != nil, decodedTitleAt == nil {
+            decodedTitleAt = idx
+        }
+        if let value, value.year != nil, decodedYearAt == nil {
+            decodedYearAt = idx
+        }
+    }
+
+    #expect(decodedTitleAt != nil, "title should populate at some prefix")
+    #expect(decodedYearAt != nil, "year should populate at some prefix")
+    if let titleIdx = decodedTitleAt, let yearIdx = decodedYearAt {
+        #expect(titleIdx <= yearIdx, "title appears before year in the source")
+    }
+}
+
+@Test func emptyFragmentDoesNotCrash() {
+    let value = decodePartial(Movie.self, from: "")
+    #expect(value == nil)
+}
+
+@Test func unrecoverableFragmentReturnsNil() {
+    // `}` with no opener is unrecoverable — must not throw.
+    let value = decodePartial(Movie.self, from: "}")
+    #expect(value == nil)
+}
+
+@Test func fullDocumentDecodesBothFields() {
+    let value = decodePartial(
+        Movie.self,
+        from: "{\"title\":\"Inception\",\"year\":2010}"
+    )
+    #expect(value?.title == "Inception")
+    #expect(value?.year == 2010)
+}
+
+// MARK: - Test helper that mirrors Cast/API/CastModel+Stream.swift's `decodePartial`
+
+private func decodePartial<T: Castable>(_: T.Type, from buffer: String) -> T.PartiallyGenerated? {
+    let candidate: String
+    switch JSONRepair.repair(buffer) {
+    case let .ok(value):
+        candidate = value
+    case let .repaired(value, _):
+        candidate = value
+    case .unrecoverable:
+        return nil
+    }
+    return try? JSONDecoder().decode(T.PartiallyGenerated.self, from: Data(candidate.utf8))
+}


### PR DESCRIPTION
## Summary
- New `castStream(_:as:system:config:)` returning `AsyncThrowingStream<PartialResult<T>, Error>`.
- `@Castable` macro now synthesizes a nested `PartiallyGenerated` Optional-field mirror.
- Targeted addition to vendored `MLXStructured/Generate.swift` for a Grammar-input chunk stream (modification marker added per Apache-2.0 §4(b)).

Closes #35.

## Test plan
- [x] swift build
- [x] swift test --filter CastMacroTests (23 tests, including 6 new PartiallyGenerated expansion tests)
- [x] swift test --filter PartialResultDecodeTests (4 tests, progressive-fragment decode coverage)
- [x] swift test --filter CastTests (full library suite, 129 tests, all passing)
- [ ] cd Examples && swift build (worktree-local SPM identifier limitation; verified manually after merge / will pass on CI which checks out into Cast/)
- [ ] Manual: swift run -c release Streaming (local only, requires model)