### PR TITLE
fix(api): re-export Collections + JSONSchema from Cast (#74)

### DIFF
--- a/Examples/Package.swift
+++ b/Examples/Package.swift
@@ -10,126 +10,70 @@ let package = Package(
     ],
     dependencies: [
         .package(path: ".."),
-        .package(url: "https://github.com/ml-explore/mlx-swift-lm.git", from: "2.30.0"),
-        .package(url: "https://github.com/petrukha-ivan/swift-json-schema.git", from: "2.0.2"),
-        .package(url: "https://github.com/apple/swift-collections.git", from: "1.3.0")
+        .package(url: "https://github.com/ml-explore/mlx-swift-lm.git", from: "2.30.0")
     ],
     targets: [
         .executableTarget(name: "Smoketest", dependencies: [.product(name: "Cast", package: "Cast")]),
         .executableTarget(
             name: "HelloCast",
-            dependencies: [
-                .product(name: "Cast", package: "Cast"),
-                .product(name: "JSONSchema", package: "swift-json-schema"),
-                .product(name: "Collections", package: "swift-collections")
-            ]
+            dependencies: [.product(name: "Cast", package: "Cast")]
         ),
         .executableTarget(
             name: "PropertyWrappersTour",
-            dependencies: [
-                .product(name: "Cast", package: "Cast"),
-                .product(name: "JSONSchema", package: "swift-json-schema"),
-                .product(name: "Collections", package: "swift-collections")
-            ]
+            dependencies: [.product(name: "Cast", package: "Cast")]
         ),
         .executableTarget(
             name: "NestedTypes",
-            dependencies: [
-                .product(name: "Cast", package: "Cast"),
-                .product(name: "JSONSchema", package: "swift-json-schema"),
-                .product(name: "Collections", package: "swift-collections")
-            ]
+            dependencies: [.product(name: "Cast", package: "Cast")]
         ),
         .executableTarget(name: "Classify", dependencies: [.product(name: "Cast", package: "Cast")]),
         .executableTarget(
             name: "GenerationModes",
-            dependencies: [
-                .product(name: "Cast", package: "Cast"),
-                .product(name: "JSONSchema", package: "swift-json-schema"),
-                .product(name: "Collections", package: "swift-collections")
-            ]
+            dependencies: [.product(name: "Cast", package: "Cast")]
         ),
         .executableTarget(
             name: "Cancellation",
-            dependencies: [
-                .product(name: "Cast", package: "Cast"),
-                .product(name: "JSONSchema", package: "swift-json-schema"),
-                .product(name: "Collections", package: "swift-collections")
-            ]
+            dependencies: [.product(name: "Cast", package: "Cast")]
         ),
         .executableTarget(
             name: "PrepareWarmup",
-            dependencies: [
-                .product(name: "Cast", package: "Cast"),
-                .product(name: "JSONSchema", package: "swift-json-schema"),
-                .product(name: "Collections", package: "swift-collections")
-            ]
+            dependencies: [.product(name: "Cast", package: "Cast")]
         ),
         .executableTarget(
             name: "CallerManagedLoading",
             dependencies: [
                 .product(name: "Cast", package: "Cast"),
-                .product(name: "JSONSchema", package: "swift-json-schema"),
-                .product(name: "Collections", package: "swift-collections"),
                 .product(name: "MLXLLM", package: "mlx-swift-lm"),
                 .product(name: "MLXLMCommon", package: "mlx-swift-lm")
             ]
         ),
         .executableTarget(
             name: "ValidatorAndExcluding",
-            dependencies: [
-                .product(name: "Cast", package: "Cast"),
-                .product(name: "JSONSchema", package: "swift-json-schema"),
-                .product(name: "Collections", package: "swift-collections")
-            ]
+            dependencies: [.product(name: "Cast", package: "Cast")]
         ),
         .executableTarget(
             name: "ErrorHandling",
-            dependencies: [
-                .product(name: "Cast", package: "Cast"),
-                .product(name: "JSONSchema", package: "swift-json-schema"),
-                .product(name: "Collections", package: "swift-collections")
-            ]
+            dependencies: [.product(name: "Cast", package: "Cast")]
         ),
         .executableTarget(
             name: "ChatTemplates",
-            dependencies: [
-                .product(name: "Cast", package: "Cast"),
-                .product(name: "JSONSchema", package: "swift-json-schema"),
-                .product(name: "Collections", package: "swift-collections")
-            ]
+            dependencies: [.product(name: "Cast", package: "Cast")]
         ),
         .executableTarget(
             name: "Extract",
-            dependencies: [
-                .product(name: "Cast", package: "Cast"),
-                .product(name: "JSONSchema", package: "swift-json-schema"),
-                .product(name: "Collections", package: "swift-collections")
-            ]
+            dependencies: [.product(name: "Cast", package: "Cast")]
         ),
         .executableTarget(
             name: "CastBench",
-            dependencies: [
-                .product(name: "Cast", package: "Cast"),
-                .product(name: "JSONSchema", package: "swift-json-schema"),
-                .product(name: "Collections", package: "swift-collections")
-            ]
+            dependencies: [.product(name: "Cast", package: "Cast")]
         ),
         .executableTarget(
             name: "Streaming",
-            dependencies: [
-                .product(name: "Cast", package: "Cast"),
-                .product(name: "JSONSchema", package: "swift-json-schema"),
-                .product(name: "Collections", package: "swift-collections")
-            ]
+            dependencies: [.product(name: "Cast", package: "Cast")]
         ),
         .executableTarget(
             name: "SwiftUIDemo",
-            dependencies: [
-                .product(name: "Cast", package: "Cast"),
-                .product(name: "JSONSchema", package: "swift-json-schema"),
-                .product(name: "Collections", package: "swift-collections")
-            ]
+            dependencies: [.product(name: "Cast", package: "Cast")]
         )
     ]
 )

--- a/Examples/Sources/CallerManagedLoading/main.swift
+++ b/Examples/Sources/CallerManagedLoading/main.swift
@@ -4,9 +4,7 @@
 // and free-form chat, or you want a single download to back several CastModels.
 
 import Cast
-import Collections
 import Foundation
-import JSONSchema
 import MLXLLM
 import MLXLMCommon
 

--- a/Examples/Sources/Cancellation/main.swift
+++ b/Examples/Sources/Cancellation/main.swift
@@ -8,9 +8,7 @@
 //    whatever bytes the model produced before the cancel landed.
 
 import Cast
-import Collections
 import Foundation
-import JSONSchema
 
 @Castable
 struct LongStory {

--- a/Examples/Sources/CastBench/main.swift
+++ b/Examples/Sources/CastBench/main.swift
@@ -2,9 +2,7 @@
 // grammar overhead, and (optionally) compare against unconstrained generation.
 
 import Cast
-import Collections
 import Foundation
-import JSONSchema
 
 @Castable
 struct Person {

--- a/Examples/Sources/ChatTemplates/main.swift
+++ b/Examples/Sources/ChatTemplates/main.swift
@@ -6,9 +6,7 @@
 // <start_of_turn>. No per-family code paths in Cast.
 
 import Cast
-import Collections
 import Foundation
-import JSONSchema
 
 @Castable
 struct Greeting {

--- a/Examples/Sources/ChatTemplates/main.swift
+++ b/Examples/Sources/ChatTemplates/main.swift
@@ -1,9 +1,9 @@
 // What this shows: the same prompt routed through five different model
 // families to demonstrate cross-family chat-template support. Cast hands a
 // flat "(system)\n\n(prompt)" string to MLXLMCommon's processor.prepare,
-// which applies each tokenizer's chat_template — Qwen <|im_start|>,
-// Llama <|begin_of_text|>, Mistral [INST], Phi <|user|>, Gemma
-// <start_of_turn>. No per-family code paths in Cast.
+// which applies each tokenizer's chat_template — Qwen `<|im_start|>`,
+// Llama `<|begin_of_text|>`, Mistral `[INST]`, Phi `<|user|>`, Gemma
+// `<start_of_turn>`. No per-family code paths in Cast.
 
 import Cast
 import Foundation

--- a/Examples/Sources/ErrorHandling/main.swift
+++ b/Examples/Sources/ErrorHandling/main.swift
@@ -3,9 +3,7 @@
 // unsupportedType errors before the user ever issues a request.
 
 import Cast
-import Collections
 import Foundation
-import JSONSchema
 
 @Castable
 struct Quote {

--- a/Examples/Sources/Extract/main.swift
+++ b/Examples/Sources/Extract/main.swift
@@ -1,9 +1,7 @@
 // What this shows: extract structured fields from a block of unstructured text via model.extract(from:as:instruction:).
 
 import Cast
-import Collections
 import Foundation
-import JSONSchema
 
 /// Optional fields demonstrate the no-invention contract: a missing
 /// value in the source can decode to `nil` rather than being hallucinated.

--- a/Examples/Sources/GenerationModes/main.swift
+++ b/Examples/Sources/GenerationModes/main.swift
@@ -3,9 +3,7 @@
 // JSON string.
 
 import Cast
-import Collections
 import Foundation
-import JSONSchema
 
 @Castable
 struct BookSummary {

--- a/Examples/Sources/HelloCast/main.swift
+++ b/Examples/Sources/HelloCast/main.swift
@@ -2,9 +2,7 @@
 // value with a single cast(_:) call. The minimal first-touch example.
 
 import Cast
-import Collections
 import Foundation
-import JSONSchema
 
 @Castable
 struct Person {

--- a/Examples/Sources/NestedTypes/main.swift
+++ b/Examples/Sources/NestedTypes/main.swift
@@ -4,9 +4,7 @@
 // inventing extra keys at any level.
 
 import Cast
-import Collections
 import Foundation
-import JSONSchema
 
 @Castable
 struct Author {

--- a/Examples/Sources/PrepareWarmup/main.swift
+++ b/Examples/Sources/PrepareWarmup/main.swift
@@ -5,9 +5,7 @@
 // cost up front instead of inside your first user-visible call.
 
 import Cast
-import Collections
 import Foundation
-import JSONSchema
 
 @Castable
 struct Note {

--- a/Examples/Sources/PropertyWrappersTour/main.swift
+++ b/Examples/Sources/PropertyWrappersTour/main.swift
@@ -3,9 +3,7 @@
 // ValidatorAndExcluding example, per the issue conventions.
 
 import Cast
-import Collections
 import Foundation
-import JSONSchema
 
 @Castable
 struct Recipe {

--- a/Examples/Sources/Streaming/main.swift
+++ b/Examples/Sources/Streaming/main.swift
@@ -2,9 +2,7 @@
 // field appears as the model fills it in.
 
 import Cast
-import Collections
 import Foundation
-import JSONSchema
 
 @Castable
 struct Recipe {

--- a/Examples/Sources/SwiftUIDemo/main.swift
+++ b/Examples/Sources/SwiftUIDemo/main.swift
@@ -3,8 +3,6 @@
 #if os(macOS) || os(iOS)
 
     import Cast
-    import Collections
-    import JSONSchema
     import Observation
     import SwiftUI
 

--- a/Examples/Sources/ValidatorAndExcluding/main.swift
+++ b/Examples/Sources/ValidatorAndExcluding/main.swift
@@ -7,9 +7,7 @@
 //      one prompt should populate only a subset of a struct's fields.
 
 import Cast
-import Collections
 import Foundation
-import JSONSchema
 
 @Castable
 struct Contact {

--- a/Sources/Cast/API/Castable.swift
+++ b/Sources/Cast/API/Castable.swift
@@ -1,3 +1,6 @@
+@_exported import Collections
+@_exported import JSONSchema
+
 /// Generates a JSON Schema and `Decodable` conformance for a struct, making it
 /// usable as the output type of ``CastModel/cast(_:as:system:config:didGenerate:)-1jybk``.
 ///

--- a/Sources/Cast/Cast.docc/Examples/CallerManagedLoading.md
+++ b/Sources/Cast/Cast.docc/Examples/CallerManagedLoading.md
@@ -16,9 +16,7 @@ Full source: [Examples/Sources/CallerManagedLoading/main.swift](https://github.c
 // and free-form chat, or you want a single download to back several CastModels.
 
 import Cast
-import Collections
 import Foundation
-import JSONSchema
 import MLXLLM
 import MLXLMCommon
 

--- a/Sources/Cast/Cast.docc/Examples/Cancellation.md
+++ b/Sources/Cast/Cast.docc/Examples/Cancellation.md
@@ -24,9 +24,7 @@ Full source: [Examples/Sources/Cancellation/main.swift](https://github.com/jayla
 //    whatever bytes the model produced before the cancel landed.
 
 import Cast
-import Collections
 import Foundation
-import JSONSchema
 
 @Castable
 struct LongStory {

--- a/Sources/Cast/Cast.docc/Examples/CastBench.md
+++ b/Sources/Cast/Cast.docc/Examples/CastBench.md
@@ -12,9 +12,7 @@ Full source: [Examples/Sources/CastBench/main.swift](https://github.com/jaylann/
 // grammar overhead, and (optionally) compare against unconstrained generation.
 
 import Cast
-import Collections
 import Foundation
-import JSONSchema
 
 @Castable
 struct Person {

--- a/Sources/Cast/Cast.docc/Examples/ChatTemplates.md
+++ b/Sources/Cast/Cast.docc/Examples/ChatTemplates.md
@@ -3,9 +3,9 @@
 the same prompt routed through five different model
 families to demonstrate cross-family chat-template support. Cast hands a
 flat "(system)\n\n(prompt)" string to MLXLMCommon's processor.prepare,
-which applies each tokenizer's chat_template — Qwen <|im_start|>,
-Llama <|begin_of_text|>, Mistral [INST], Phi <|user|>, Gemma
-<start_of_turn>. No per-family code paths in Cast.
+which applies each tokenizer's chat_template — Qwen `<|im_start|>`,
+Llama `<|begin_of_text|>`, Mistral `[INST]`, Phi `<|user|>`, Gemma
+`<start_of_turn>`. No per-family code paths in Cast.
 
 ## Source
 
@@ -15,9 +15,9 @@ Full source: [Examples/Sources/ChatTemplates/main.swift](https://github.com/jayl
 // What this shows: the same prompt routed through five different model
 // families to demonstrate cross-family chat-template support. Cast hands a
 // flat "(system)\n\n(prompt)" string to MLXLMCommon's processor.prepare,
-// which applies each tokenizer's chat_template — Qwen <|im_start|>,
-// Llama <|begin_of_text|>, Mistral [INST], Phi <|user|>, Gemma
-// <start_of_turn>. No per-family code paths in Cast.
+// which applies each tokenizer's chat_template — Qwen `<|im_start|>`,
+// Llama `<|begin_of_text|>`, Mistral `[INST]`, Phi `<|user|>`, Gemma
+// `<start_of_turn>`. No per-family code paths in Cast.
 
 import Cast
 import Foundation

--- a/Sources/Cast/Cast.docc/Examples/ChatTemplates.md
+++ b/Sources/Cast/Cast.docc/Examples/ChatTemplates.md
@@ -20,9 +20,7 @@ Full source: [Examples/Sources/ChatTemplates/main.swift](https://github.com/jayl
 // <start_of_turn>. No per-family code paths in Cast.
 
 import Cast
-import Collections
 import Foundation
-import JSONSchema
 
 @Castable
 struct Greeting {

--- a/Sources/Cast/Cast.docc/Examples/ErrorHandling.md
+++ b/Sources/Cast/Cast.docc/Examples/ErrorHandling.md
@@ -14,9 +14,7 @@ Full source: [Examples/Sources/ErrorHandling/main.swift](https://github.com/jayl
 // unsupportedType errors before the user ever issues a request.
 
 import Cast
-import Collections
 import Foundation
-import JSONSchema
 
 @Castable
 struct Quote {

--- a/Sources/Cast/Cast.docc/Examples/Extract.md
+++ b/Sources/Cast/Cast.docc/Examples/Extract.md
@@ -10,9 +10,7 @@ Full source: [Examples/Sources/Extract/main.swift](https://github.com/jaylann/Ca
 // What this shows: extract structured fields from a block of unstructured text via model.extract(from:as:instruction:).
 
 import Cast
-import Collections
 import Foundation
-import JSONSchema
 
 /// Optional fields demonstrate the no-invention contract: a missing
 /// value in the source can decode to `nil` rather than being hallucinated.

--- a/Sources/Cast/Cast.docc/Examples/GenerationModes.md
+++ b/Sources/Cast/Cast.docc/Examples/GenerationModes.md
@@ -14,9 +14,7 @@ Full source: [Examples/Sources/GenerationModes/main.swift](https://github.com/ja
 // JSON string.
 
 import Cast
-import Collections
 import Foundation
-import JSONSchema
 
 @Castable
 struct BookSummary {

--- a/Sources/Cast/Cast.docc/Examples/HelloCast.md
+++ b/Sources/Cast/Cast.docc/Examples/HelloCast.md
@@ -12,9 +12,7 @@ Full source: [Examples/Sources/HelloCast/main.swift](https://github.com/jaylann/
 // value with a single cast(_:) call. The minimal first-touch example.
 
 import Cast
-import Collections
 import Foundation
-import JSONSchema
 
 @Castable
 struct Person {

--- a/Sources/Cast/Cast.docc/Examples/NestedTypes.md
+++ b/Sources/Cast/Cast.docc/Examples/NestedTypes.md
@@ -16,9 +16,7 @@ Full source: [Examples/Sources/NestedTypes/main.swift](https://github.com/jaylan
 // inventing extra keys at any level.
 
 import Cast
-import Collections
 import Foundation
-import JSONSchema
 
 @Castable
 struct Author {

--- a/Sources/Cast/Cast.docc/Examples/PrepareWarmup.md
+++ b/Sources/Cast/Cast.docc/Examples/PrepareWarmup.md
@@ -18,9 +18,7 @@ Full source: [Examples/Sources/PrepareWarmup/main.swift](https://github.com/jayl
 // cost up front instead of inside your first user-visible call.
 
 import Cast
-import Collections
 import Foundation
-import JSONSchema
 
 @Castable
 struct Note {

--- a/Sources/Cast/Cast.docc/Examples/PropertyWrappersTour.md
+++ b/Sources/Cast/Cast.docc/Examples/PropertyWrappersTour.md
@@ -14,9 +14,7 @@ Full source: [Examples/Sources/PropertyWrappersTour/main.swift](https://github.c
 // ValidatorAndExcluding example, per the issue conventions.
 
 import Cast
-import Collections
 import Foundation
-import JSONSchema
 
 @Castable
 struct Recipe {

--- a/Sources/Cast/Cast.docc/Examples/Streaming.md
+++ b/Sources/Cast/Cast.docc/Examples/Streaming.md
@@ -12,9 +12,7 @@ Full source: [Examples/Sources/Streaming/main.swift](https://github.com/jaylann/
 // field appears as the model fills it in.
 
 import Cast
-import Collections
 import Foundation
-import JSONSchema
 
 @Castable
 struct Recipe {

--- a/Sources/Cast/Cast.docc/Examples/SwiftUIDemo.md
+++ b/Sources/Cast/Cast.docc/Examples/SwiftUIDemo.md
@@ -12,8 +12,6 @@ Full source: [Examples/Sources/SwiftUIDemo/main.swift](https://github.com/jaylan
 #if os(macOS) || os(iOS)
 
     import Cast
-    import Collections
-    import JSONSchema
     import Observation
     import SwiftUI
 

--- a/Sources/Cast/Cast.docc/Examples/ValidatorAndExcluding.md
+++ b/Sources/Cast/Cast.docc/Examples/ValidatorAndExcluding.md
@@ -22,9 +22,7 @@ Full source: [Examples/Sources/ValidatorAndExcluding/main.swift](https://github.
 //      one prompt should populate only a subset of a struct's fields.
 
 import Cast
-import Collections
 import Foundation
-import JSONSchema
 
 @Castable
 struct Contact {

--- a/Tests/CastTests/ReExportsTest.swift
+++ b/Tests/CastTests/ReExportsTest.swift
@@ -1,0 +1,20 @@
+// Locks the single-import contract: consumers should be able to write only
+// `import Cast` and still reach `OrderedDictionary` (Collections) and
+// `JSONSchema`. Compilation alone is the assertion — if either re-export in
+// `Sources/Cast/API/Castable.swift` is removed, this file stops compiling.
+
+import Cast
+import Testing
+
+@Suite("Re-exports")
+struct ReExportsTest {
+    @Test("OrderedDictionary and JSONSchema reachable via `import Cast` only")
+    func reExportedSymbolsAreReachable() {
+        var dict = OrderedDictionary<String, Int>()
+        dict["a"] = 1
+        #expect(dict["a"] == 1)
+
+        let schema = JSONSchema.string()
+        #expect(String(describing: schema).isEmpty == false)
+    }
+}


### PR DESCRIPTION
## Summary

The `@Castable` macro expansion references `JSONSchema` and `OrderedDictionary` directly, so consumers had to add three imports (`import Cast` + `import Collections` + `import JSONSchema`) instead of the one the README claims is sufficient. Without the extra imports, the build fails with `cannot find type 'JSONSchema' in scope` *inside* the macro expansion — which is opaque if you haven't seen it before.

This PR adds `@_exported import Collections` and `@_exported import JSONSchema` to `Sources/Cast/API/Castable.swift`, then drops the now-redundant package deps from `Examples/Package.swift` and the `import` lines from every example file.

## Changes

- `Sources/Cast/API/Castable.swift` — re-export `Collections` and `JSONSchema`.
- `Examples/Package.swift` — drop `swift-json-schema` and `swift-collections` from package + target deps.
- `Examples/Sources/*/main.swift` — drop `import Collections` and `import JSONSchema` lines.
- `Sources/Cast/Cast.docc/Examples/*.md` — regenerated from updated examples via `scripts/generate-example-docs.sh` (also added the previously-missing `ChatTemplates.md`).

## Test Plan

- [x] `swift build` at repo root passes
- [x] `swift test --filter` passes for macro/schema/wrapper/prompt/validator/CastEnum suites (no new failures; pre-existing MLX-runtime crash on `Index out of range` is unrelated to this change and reproduces on `stage`)
- [ ] `cd Examples && swift build` — verified by CI from the `Cast/` checkout (locally fails inside this worktree due to the documented `unknown package 'Cast'` path-package quirk for non-`Cast/`-named worktrees)

Closes #74

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Collections and JSONSchema are now re-exported from the Cast module, allowing access to these libraries with a single `import Cast` statement.

* **Documentation**
  * Updated all examples to remove unused imports and improve code clarity.
  * Improved ChatTemplates documentation formatting for chat-template markers.

* **Tests**
  * Added test coverage to ensure re-exported dependencies are properly accessible to consumers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->