### PR TITLE
feat(prompt): surface schema-encoding failures as CastError (#85)

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -246,6 +246,15 @@ Then derive a `Date` from `event.when.iso8601` at the call site.
 
 ---
 
+## Source-breaking changes in v1.0
+
+If you call any of the surfaces below directly, update your call sites:
+
+- `PromptEngine.buildPrompt(schema:userPrompt:)` and `PromptEngine.buildExtractionPrompt(schema:source:userPrompt:)` are now `throws` — wrap calls in `try` and catch `CastError.schemaGenerationFailed` for the schema-JSON-encoding failure case (rare; only triggered by non-JSON-finite schema constants like `Double.nan`).
+
+---
+
+
 ## Known sharp edges (and where to follow them)
 
 | Issue | Status | Workaround until then |

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -250,7 +250,7 @@ Then derive a `Date` from `event.when.iso8601` at the call site.
 
 If you call any of the surfaces below directly, update your call sites:
 
-- `PromptEngine.buildPrompt(schema:userPrompt:)` and `PromptEngine.buildExtractionPrompt(schema:source:userPrompt:)` are now `throws` — wrap calls in `try` and catch `CastError.schemaGenerationFailed` for the schema-JSON-encoding failure case (rare; only triggered by non-JSON-finite schema constants like `Double.nan`).
+- `PromptEngine.buildPrompt(userPrompt:schema:annotations:system:)` and `PromptEngine.buildExtractionPrompt(text:instruction:schema:annotations:system:)` are now `throws` — wrap calls in `try` and catch `CastError.schemaGenerationFailed` for the schema-JSON-encoding failure case (rare; only triggered by non-JSON-finite schema constants like `Double.nan`).
 
 ---
 

--- a/Sources/Cast/API/CastModel+Extract.swift
+++ b/Sources/Cast/API/CastModel+Extract.swift
@@ -48,7 +48,7 @@ public extension CastModel {
             throw CastError.schemaGenerationFailed(error.localizedDescription)
         }
 
-        let built = PromptEngine.buildExtractionPrompt(
+        let built = try PromptEngine.buildExtractionPrompt(
             text: text,
             instruction: instruction,
             schema: schema,

--- a/Sources/Cast/API/CastModel+Generation.swift
+++ b/Sources/Cast/API/CastModel+Generation.swift
@@ -48,7 +48,7 @@ public extension CastModel {
             throw CastError.schemaGenerationFailed(error.localizedDescription)
         }
 
-        let built = PromptEngine.buildPrompt(
+        let built = try PromptEngine.buildPrompt(
             userPrompt: prompt,
             schema: schema,
             annotations: annotations,
@@ -85,7 +85,7 @@ public extension CastModel {
             throw CastError.schemaGenerationFailed(error.localizedDescription)
         }
 
-        let built = PromptEngine.buildPrompt(
+        let built = try PromptEngine.buildPrompt(
             userPrompt: prompt,
             schema: schema,
             annotations: annotations,

--- a/Sources/Cast/API/CastModel+Stream.swift
+++ b/Sources/Cast/API/CastModel+Stream.swift
@@ -88,7 +88,7 @@ public extension CastModel {
             throw CastError.schemaGenerationFailed(error.localizedDescription)
         }
 
-        let built = PromptEngine.buildPrompt(
+        let built = try PromptEngine.buildPrompt(
             userPrompt: prompt,
             schema: schema,
             annotations: annotations,

--- a/Sources/Cast/Bench/Instrumentation.swift
+++ b/Sources/Cast/Bench/Instrumentation.swift
@@ -81,7 +81,7 @@ enum BenchmarkInstrumentation {
         } catch {
             throw CastError.schemaGenerationFailed(error.localizedDescription)
         }
-        let built = PromptEngine.buildPrompt(
+        let built = try PromptEngine.buildPrompt(
             userPrompt: prompt,
             schema: schema,
             annotations: annotations,

--- a/Sources/Cast/Prompt/PromptEngine.swift
+++ b/Sources/Cast/Prompt/PromptEngine.swift
@@ -2,6 +2,20 @@ import Foundation
 import JSONSchema
 
 public enum PromptEngine {
+    /// Build a system + user prompt pair that embeds the JSON schema the
+    /// model must conform to. When `system` is supplied, it is returned
+    /// verbatim as the system message; otherwise a default system message
+    /// is synthesized from the schema and any per-field annotations.
+    ///
+    /// - Parameters:
+    ///   - userPrompt: The user-facing instruction returned as the user message.
+    ///   - schema: The JSON schema the output must conform to.
+    ///   - annotations: Optional per-field guidance (description, examples).
+    ///   - system: Optional override for the system message.
+    /// - Throws: ``CastError/schemaGenerationFailed(_:)`` if the schema
+    ///   cannot be JSON-encoded (e.g. it carries a non-finite `Double`
+    ///   constant such as `.nan` that `JSONEncoder` rejects under its
+    ///   default `nonConformingFloatEncodingStrategy`).
     public static func buildPrompt(
         userPrompt: String,
         schema: JSONSchema,
@@ -94,6 +108,10 @@ public enum PromptEngine {
     ///   - schema: The JSON schema the output must conform to.
     ///   - annotations: Optional per-field guidance (description, examples).
     ///   - system: Optional override for the system message.
+    /// - Throws: ``CastError/schemaGenerationFailed(_:)`` if the schema
+    ///   cannot be JSON-encoded (e.g. it carries a non-finite `Double`
+    ///   constant such as `.nan` that `JSONEncoder` rejects under its
+    ///   default `nonConformingFloatEncodingStrategy`).
     public static func buildExtractionPrompt(
         text: String,
         instruction: String,

--- a/Sources/Cast/Prompt/PromptEngine.swift
+++ b/Sources/Cast/Prompt/PromptEngine.swift
@@ -7,11 +7,11 @@ public enum PromptEngine {
         schema: JSONSchema,
         annotations: [String: FieldAnnotation] = [:],
         system: String? = nil
-    ) -> (system: String, user: String) {
+    ) throws -> (system: String, user: String) {
         let systemPrompt: String = if let system {
             system
         } else {
-            buildDefaultSystem(schema: schema, annotations: annotations)
+            try buildDefaultSystem(schema: schema, annotations: annotations)
         }
         return (system: systemPrompt, user: userPrompt)
     }
@@ -19,7 +19,7 @@ public enum PromptEngine {
     private static func buildDefaultSystem(
         schema: JSONSchema,
         annotations: [String: FieldAnnotation]
-    ) -> String {
+    ) throws -> String {
         var parts: [String] = []
 
         parts.append("You are a structured data extraction assistant.")
@@ -28,13 +28,19 @@ public enum PromptEngine {
 
         let encoder = JSONEncoder()
         encoder.outputFormatting = [.sortedKeys, .prettyPrinted]
-        if let data = try? encoder.encode(schema),
-           let str = String(data: data, encoding: .utf8) {
-            parts.append("JSON Schema:")
-            parts.append(str)
-        } else {
-            parts.append("[Schema encoding failed]")
+        let data: Data
+        do {
+            data = try encoder.encode(schema)
+        } catch {
+            throw CastError.schemaGenerationFailed(
+                "Failed to encode JSON schema: \(error.localizedDescription)"
+            )
         }
+        guard let str = String(data: data, encoding: .utf8) else {
+            throw CastError.schemaGenerationFailed("Encoded JSON schema is not valid UTF-8")
+        }
+        parts.append("JSON Schema:")
+        parts.append(str)
 
         let guidance = annotations.sorted(by: { $0.key < $1.key }).compactMap { field, ann -> String? in
             var items: [String] = []
@@ -94,8 +100,12 @@ public enum PromptEngine {
         schema: JSONSchema,
         annotations: [String: FieldAnnotation] = [:],
         system: String? = nil
-    ) -> (system: String, user: String) {
-        let systemPrompt = system ?? buildExtractionSystem(schema: schema, annotations: annotations)
+    ) throws -> (system: String, user: String) {
+        let systemPrompt: String = if let system {
+            system
+        } else {
+            try buildExtractionSystem(schema: schema, annotations: annotations)
+        }
         let user = buildExtractionUser(text: text, instruction: instruction)
         return (system: systemPrompt, user: user)
     }
@@ -103,7 +113,7 @@ public enum PromptEngine {
     private static func buildExtractionSystem(
         schema: JSONSchema,
         annotations: [String: FieldAnnotation]
-    ) -> String {
+    ) throws -> String {
         var parts: [String] = []
 
         parts.append("You are a structured data extraction assistant.")
@@ -116,13 +126,19 @@ public enum PromptEngine {
 
         let encoder = JSONEncoder()
         encoder.outputFormatting = [.sortedKeys, .prettyPrinted]
-        if let data = try? encoder.encode(schema),
-           let str = String(data: data, encoding: .utf8) {
-            parts.append("JSON Schema:")
-            parts.append(str)
-        } else {
-            parts.append("[Schema encoding failed]")
+        let data: Data
+        do {
+            data = try encoder.encode(schema)
+        } catch {
+            throw CastError.schemaGenerationFailed(
+                "Failed to encode JSON schema: \(error.localizedDescription)"
+            )
         }
+        guard let str = String(data: data, encoding: .utf8) else {
+            throw CastError.schemaGenerationFailed("Encoded JSON schema is not valid UTF-8")
+        }
+        parts.append("JSON Schema:")
+        parts.append(str)
 
         let guidance = annotations.sorted(by: { $0.key < $1.key }).compactMap { field, ann -> String? in
             var items: [String] = []

--- a/Tests/CastTests/PromptEngineTests.swift
+++ b/Tests/CastTests/PromptEngineTests.swift
@@ -4,12 +4,12 @@ import Testing
 
 @Suite("PromptEngine")
 struct PromptEngineTests {
-    @Test func defaultSystemIncludesSchema() {
+    @Test func defaultSystemIncludesSchema() throws {
         let schema = JSONSchema.object(
             properties: ["name": .string(), "age": .integer()],
             required: ["name", "age"]
         )
-        let result = PromptEngine.buildPrompt(userPrompt: "Extract info", schema: schema)
+        let result = try PromptEngine.buildPrompt(userPrompt: "Extract info", schema: schema)
 
         #expect(result.system.contains("JSON Schema"))
         #expect(result.system.contains("name"))
@@ -17,9 +17,9 @@ struct PromptEngineTests {
         #expect(result.user == "Extract info")
     }
 
-    @Test func customSystemOverride() {
+    @Test func customSystemOverride() throws {
         let schema = JSONSchema.object()
-        let result = PromptEngine.buildPrompt(
+        let result = try PromptEngine.buildPrompt(
             userPrompt: "test",
             schema: schema,
             system: "Custom system prompt."
@@ -27,44 +27,44 @@ struct PromptEngineTests {
         #expect(result.system == "Custom system prompt.")
     }
 
-    @Test func descriptionAppearsInGuidance() {
+    @Test func descriptionAppearsInGuidance() throws {
         let schema = JSONSchema.object(properties: ["title": .string()], required: ["title"])
         let annotations: [String: FieldAnnotation] = [
             "title": FieldAnnotation(description: "The movie title exactly as written")
         ]
-        let result = PromptEngine.buildPrompt(userPrompt: "Extract", schema: schema, annotations: annotations)
+        let result = try PromptEngine.buildPrompt(userPrompt: "Extract", schema: schema, annotations: annotations)
 
         #expect(result.system.contains("The movie title exactly as written"))
         #expect(result.system.contains("Field guidance"))
     }
 
-    @Test func examplesAppearInGuidance() {
+    @Test func examplesAppearInGuidance() throws {
         let schema = JSONSchema.object(properties: ["summary": .string()], required: ["summary"])
         let annotations: [String: FieldAnnotation] = [
             "summary": FieldAnnotation(examples: ["Great pacing", "Weak third act"])
         ]
-        let result = PromptEngine.buildPrompt(userPrompt: "Summarize", schema: schema, annotations: annotations)
+        let result = try PromptEngine.buildPrompt(userPrompt: "Summarize", schema: schema, annotations: annotations)
 
         #expect(result.system.contains("Great pacing"))
         #expect(result.system.contains("Weak third act"))
     }
 
-    @Test func emptyAnnotationsNoGuidance() {
+    @Test func emptyAnnotationsNoGuidance() throws {
         let schema = JSONSchema.object(properties: ["x": .string()], required: ["x"])
-        let result = PromptEngine.buildPrompt(userPrompt: "test", schema: schema)
+        let result = try PromptEngine.buildPrompt(userPrompt: "test", schema: schema)
         #expect(!result.system.contains("Field guidance"))
     }
 
-    @Test func containsJSONInstruction() {
+    @Test func containsJSONInstruction() throws {
         let schema = JSONSchema.object()
-        let result = PromptEngine.buildPrompt(userPrompt: "test", schema: schema)
+        let result = try PromptEngine.buildPrompt(userPrompt: "test", schema: schema)
         #expect(result.system.contains("valid JSON"))
     }
 
-    @Test func extractionPromptWrapsTextInDelimiters() {
+    @Test func extractionPromptWrapsTextInDelimiters() throws {
         let schema = JSONSchema.object()
         let source = "Invoice #4242 — total due $19.99"
-        let result = PromptEngine.buildExtractionPrompt(
+        let result = try PromptEngine.buildExtractionPrompt(
             text: source,
             instruction: "Extract the invoice number and total.",
             schema: schema
@@ -91,11 +91,11 @@ struct PromptEngineTests {
         #expect(sourceRange.upperBound <= closeMatch.range.lowerBound)
     }
 
-    @Test func extractionDelimiterNonceIsPerCall() {
+    @Test func extractionDelimiterNonceIsPerCall() throws {
         let schema = JSONSchema.object()
         let pattern = #/<<<SOURCE-([0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12})>>>/#
-        let first = PromptEngine.buildExtractionPrompt(text: "x", instruction: "Extract.", schema: schema)
-        let second = PromptEngine.buildExtractionPrompt(text: "x", instruction: "Extract.", schema: schema)
+        let first = try PromptEngine.buildExtractionPrompt(text: "x", instruction: "Extract.", schema: schema)
+        let second = try PromptEngine.buildExtractionPrompt(text: "x", instruction: "Extract.", schema: schema)
 
         guard
             let firstNonce = first.user.firstMatch(of: pattern)?.output.1,
@@ -107,10 +107,10 @@ struct PromptEngineTests {
         #expect(firstNonce != secondNonce)
     }
 
-    @Test func extractionPromptIncludesInstruction() {
+    @Test func extractionPromptIncludesInstruction() throws {
         let schema = JSONSchema.object()
         let instruction = "Extract the invoice number and total in USD."
-        let result = PromptEngine.buildExtractionPrompt(
+        let result = try PromptEngine.buildExtractionPrompt(
             text: "irrelevant",
             instruction: instruction,
             schema: schema
@@ -118,9 +118,9 @@ struct PromptEngineTests {
         #expect(result.user.contains(instruction))
     }
 
-    @Test func extractionPromptDiscouragesInvention() {
+    @Test func extractionPromptDiscouragesInvention() throws {
         let schema = JSONSchema.object()
-        let result = PromptEngine.buildExtractionPrompt(
+        let result = try PromptEngine.buildExtractionPrompt(
             text: "irrelevant",
             instruction: "Extract.",
             schema: schema
@@ -129,12 +129,12 @@ struct PromptEngineTests {
         #expect(result.system.contains("null"))
     }
 
-    @Test func extractionPromptIncludesSchema() {
+    @Test func extractionPromptIncludesSchema() throws {
         let schema = JSONSchema.object(
             properties: ["invoiceNumber": .string(), "totalUSD": .number()],
             required: ["invoiceNumber", "totalUSD"]
         )
-        let result = PromptEngine.buildExtractionPrompt(
+        let result = try PromptEngine.buildExtractionPrompt(
             text: "irrelevant",
             instruction: "Extract.",
             schema: schema
@@ -144,9 +144,9 @@ struct PromptEngineTests {
         #expect(result.system.contains("totalUSD"))
     }
 
-    @Test func extractionPromptCustomSystemOverride() {
+    @Test func extractionPromptCustomSystemOverride() throws {
         let schema = JSONSchema.object()
-        let result = PromptEngine.buildExtractionPrompt(
+        let result = try PromptEngine.buildExtractionPrompt(
             text: "irrelevant",
             instruction: "Extract.",
             schema: schema,

--- a/Tests/CastTests/PromptEngineThrowsTests.swift
+++ b/Tests/CastTests/PromptEngineThrowsTests.swift
@@ -1,0 +1,47 @@
+@testable import Cast
+import JSONSchema
+import Testing
+
+@Suite("PromptEngine throws on un-encodable schemas")
+struct PromptEngineThrowsTests {
+    /// `JSONEncoder` defaults to `.throw` for non-conforming floats, so a
+    /// schema with `Double.nan` as a numeric constant trips the encode path
+    /// without needing to widen the public API.
+    @Test func buildPromptThrowsSchemaGenerationFailedOnNaNMinimum() {
+        let schema = JSONSchema.number(minimum: .nan)
+        #expect(throws: CastError.self) {
+            _ = try PromptEngine.buildPrompt(userPrompt: "test", schema: schema)
+        }
+        do {
+            _ = try PromptEngine.buildPrompt(userPrompt: "test", schema: schema)
+            Issue.record("Expected buildPrompt to throw on NaN minimum")
+        } catch let CastError.schemaGenerationFailed(detail) {
+            #expect(detail.contains("schema") || detail.contains("UTF-8") || !detail.isEmpty)
+        } catch {
+            Issue.record("Expected CastError.schemaGenerationFailed, got \(error)")
+        }
+    }
+
+    @Test func buildExtractionPromptThrowsSchemaGenerationFailedOnNaNMinimum() {
+        let schema = JSONSchema.number(minimum: .nan)
+        #expect(throws: CastError.self) {
+            _ = try PromptEngine.buildExtractionPrompt(
+                text: "irrelevant",
+                instruction: "Extract.",
+                schema: schema
+            )
+        }
+        do {
+            _ = try PromptEngine.buildExtractionPrompt(
+                text: "irrelevant",
+                instruction: "Extract.",
+                schema: schema
+            )
+            Issue.record("Expected buildExtractionPrompt to throw on NaN minimum")
+        } catch let CastError.schemaGenerationFailed(detail) {
+            #expect(detail.contains("schema") || detail.contains("UTF-8") || !detail.isEmpty)
+        } catch {
+            Issue.record("Expected CastError.schemaGenerationFailed, got \(error)")
+        }
+    }
+}


### PR DESCRIPTION
## Summary

`PromptEngine.buildDefaultSystem` and `buildExtractionSystem` wrapped the JSON-schema encoding step in `try?` and substituted the literal string `[Schema encoding failed]` into the system prompt on failure. The model received a prompt with no schema, produced low-quality output, and the caller had no signal anything went wrong.

This PR makes `buildPrompt` and `buildExtractionPrompt` `throws` and propagates the failure as `CastError.schemaGenerationFailed`. `buildClassificationPrompt` is unaffected — it doesn't encode a schema.

## Changes

- `Sources/Cast/Prompt/PromptEngine.swift`: `buildPrompt`/`buildExtractionPrompt` now `throws`; encoding failures throw `CastError.schemaGenerationFailed`.
- `Sources/Cast/API/CastModel+Generation.swift`, `CastModel+Extract.swift`, `CastModel+Stream.swift`, `Sources/Cast/Bench/Instrumentation.swift`: callers add `try` (already in `async throws` context).
- `Tests/CastTests/PromptEngineTests.swift`: existing tests adapted to the new throws shape.

## Test Plan

- [x] `swift test --filter CastTests.PromptEngineTests` passes (12/12)
- [x] `swift test` full suite — no new failures (a pre-existing Metal-related fatal error in MLX runtime tests is unaffected; matches CLAUDE.md `requiresMetal` notes)
- [x] `swift build` confirms callers wired

## Note on failure-path testing

`JSONSchema` from `swift-json-schema` is a plain value type; with a default `JSONEncoder`, encoding never naturally throws. Constructing a synthetic failing input would require either a custom encoder injection point or mocking the schema type — both would widen the API surface beyond what this fix needs. The architectural fix surfaces the error type cleanly for any future encoding bug; the existing 12 tests prove no behavior change on the happy path.

Closes #85

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Breaking Changes**
  * Prompt-construction APIs now surface errors when schema encoding fails (previously silent); callers must handle these exceptions.

* **Documentation**
  * Added v1.0 migration notes describing source-breaking behavior and recommended try/catch guidance.

* **Tests**
  * Expanded tests to verify error behavior for schema encoding edge cases (e.g., non-JSON-finite values).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->