### PR TITLE
feat(examples): SwiftUI demo app — macOS + iOS (#44)

### DIFF
--- a/Examples/Package.swift
+++ b/Examples/Package.swift
@@ -122,6 +122,14 @@ let package = Package(
                 .product(name: "JSONSchema", package: "swift-json-schema"),
                 .product(name: "Collections", package: "swift-collections")
             ]
+        ),
+        .executableTarget(
+            name: "SwiftUIDemo",
+            dependencies: [
+                .product(name: "Cast", package: "Cast"),
+                .product(name: "JSONSchema", package: "swift-json-schema"),
+                .product(name: "Collections", package: "swift-collections")
+            ]
         )
     ]
 )

--- a/Examples/Sources/SwiftUIDemo/main.swift
+++ b/Examples/Sources/SwiftUIDemo/main.swift
@@ -1,0 +1,301 @@
+// What this shows: SwiftUI app demonstrating cast/classify/extract with live-streaming Recipe fields.
+
+#if os(macOS) || os(iOS)
+
+    import Cast
+    import Collections
+    import JSONSchema
+    import Observation
+    import SwiftUI
+
+    // MARK: - Demo Models
+
+    @Castable
+    struct Recipe {
+        @Description("Short, punchy title")
+        var title: String = ""
+
+        @MaxCount(8)
+        var ingredients: [String] = []
+
+        @CastRange(1 ... 60)
+        var prepMinutes: Int = 0
+    }
+
+    enum Sentiment: String, CastEnum, CaseIterable {
+        case positive, negative, neutral
+    }
+
+    @Castable
+    struct InvoiceFields {
+        @Description("Invoice number from the document")
+        var invoiceNumber: String = ""
+
+        @Description("Total amount in USD")
+        var totalUSD: Double = 0
+    }
+
+    // MARK: - View Model
+
+    enum DemoMode: String, CaseIterable, Identifiable {
+        case cast = "Cast"
+        case classify = "Classify"
+        case extract = "Extract"
+
+        var id: String {
+            rawValue
+        }
+    }
+
+    @MainActor
+    @Observable
+    final class DemoViewModel {
+        var modelID: String = "mlx-community/Llama-3.2-3B-Instruct-4bit"
+        var prompt: String = "Quick weeknight pasta in 20 minutes."
+        var sourceText: String = """
+        ACME Corp.
+        Invoice Number: INV-7421
+        Date: 2025-03-12
+        Total Due: $1,250.00 USD
+        """
+
+        var mode: DemoMode = .cast
+
+        var model: CastModel?
+        var isLoading: Bool = false
+        var isGenerating: Bool = false
+
+        var partialRecipe: Recipe.PartiallyGenerated?
+        var progress: Double = 0
+        var classification: Sentiment?
+        var extracted: InvoiceFields?
+        var errorMessage: String?
+
+        var generationTask: Task<Void, Never>?
+
+        var canGenerate: Bool {
+            model != nil && !isGenerating && !isLoading
+        }
+
+        func loadModel() {
+            guard !isLoading else { return }
+            isLoading = true
+            errorMessage = nil
+            let id = modelID
+            Task { [weak self] in
+                do {
+                    let loaded = try await CastModel.load(id)
+                    await MainActor.run {
+                        guard let self else { return }
+                        self.model = loaded
+                        self.isLoading = false
+                    }
+                } catch {
+                    await MainActor.run {
+                        guard let self else { return }
+                        self.errorMessage = "Load failed: \(error.localizedDescription)"
+                        self.isLoading = false
+                    }
+                }
+            }
+        }
+
+        func generate() {
+            guard let model, !isGenerating else { return }
+            errorMessage = nil
+            partialRecipe = nil
+            classification = nil
+            extracted = nil
+            progress = 0
+            isGenerating = true
+
+            let mode = self.mode
+            let prompt = self.prompt
+            let sourceText = self.sourceText
+
+            generationTask = Task { [weak self] in
+                defer {
+                    Task { @MainActor [weak self] in
+                        self?.isGenerating = false
+                    }
+                }
+
+                do {
+                    switch mode {
+                    case .cast:
+                        for try await partial in model.castStream(prompt, as: Recipe.self) {
+                            let snapshot = partial.value
+                            let pct = partial.progress
+                            await MainActor.run { [weak self] in
+                                self?.partialRecipe = snapshot
+                                self?.progress = pct
+                            }
+                        }
+                    case .classify:
+                        let result: Sentiment = try await model.classify(prompt)
+                        await MainActor.run { [weak self] in
+                            self?.classification = result
+                        }
+                    case .extract:
+                        let fields: InvoiceFields = try await model.extract(
+                            from: sourceText,
+                            instruction: prompt
+                        )
+                        await MainActor.run { [weak self] in
+                            self?.extracted = fields
+                        }
+                    }
+                } catch {
+                    await MainActor.run { [weak self] in
+                        self?.errorMessage = error.localizedDescription
+                    }
+                }
+            }
+        }
+
+        func cancel() {
+            model?.abortInFlight()
+            generationTask?.cancel()
+        }
+    }
+
+    // MARK: - Views
+
+    struct ContentView: View {
+        @State private var vm = DemoViewModel()
+
+        var body: some View {
+            Form {
+                Section("Model") {
+                    HStack {
+                        TextField("Model ID", text: $vm.modelID)
+                            .textFieldStyle(.roundedBorder)
+                            .disabled(vm.isLoading || vm.model != nil)
+                        Button(vm.model == nil ? "Load" : "Loaded") {
+                            vm.loadModel()
+                        }
+                        .disabled(vm.isLoading || vm.model != nil)
+                        if vm.isLoading {
+                            ProgressView().controlSize(.small)
+                        }
+                    }
+                }
+
+                Section("Mode") {
+                    Picker("Mode", selection: $vm.mode) {
+                        ForEach(DemoMode.allCases) { m in
+                            Text(m.rawValue).tag(m)
+                        }
+                    }
+                    .pickerStyle(.segmented)
+                }
+
+                Section(vm.mode == .extract ? "Instruction" : "Prompt") {
+                    TextField("Prompt", text: $vm.prompt, axis: .vertical)
+                        .lineLimit(2 ... 5)
+                        .textFieldStyle(.roundedBorder)
+                }
+
+                if vm.mode == .extract {
+                    Section("Source Text") {
+                        TextEditor(text: $vm.sourceText)
+                            .font(.body.monospaced())
+                            .frame(minHeight: 100)
+                    }
+                }
+
+                Section("Run") {
+                    HStack {
+                        Button("Generate") { vm.generate() }
+                            .disabled(!vm.canGenerate)
+                        Button("Cancel") { vm.cancel() }
+                            .disabled(!vm.isGenerating)
+                        if vm.isGenerating {
+                            ProgressView().controlSize(.small)
+                        }
+                    }
+                }
+
+                Section("Output") {
+                    OutputView(vm: vm)
+                }
+
+                if let error = vm.errorMessage {
+                    Section {
+                        Text(error)
+                            .foregroundStyle(.red)
+                            .font(.callout)
+                    }
+                }
+            }
+            .padding()
+            .frame(minWidth: 600, minHeight: 500)
+        }
+    }
+
+    struct OutputView: View {
+        let vm: DemoViewModel
+
+        var body: some View {
+            switch vm.mode {
+            case .cast:
+                VStack(alignment: .leading, spacing: 8) {
+                    ProgressView(value: vm.progress)
+                    LabeledContent("Title") {
+                        Text(vm.partialRecipe?.title ?? "—")
+                            .foregroundStyle(vm.partialRecipe?.title == nil ? .secondary : .primary)
+                    }
+                    LabeledContent("Prep Minutes") {
+                        Text(vm.partialRecipe?.prepMinutes.map { "\($0) min" } ?? "—")
+                            .foregroundStyle(vm.partialRecipe?.prepMinutes == nil ? .secondary : .primary)
+                    }
+                    LabeledContent("Ingredients") {
+                        if let ingredients = vm.partialRecipe?.ingredients, !ingredients.isEmpty {
+                            VStack(alignment: .trailing) {
+                                ForEach(Array(ingredients.enumerated()), id: \.offset) { _, item in
+                                    Text(item ?? "—")
+                                }
+                            }
+                        } else {
+                            Text("—").foregroundStyle(.secondary)
+                        }
+                    }
+                }
+            case .classify:
+                if let result = vm.classification {
+                    LabeledContent("Sentiment", value: result.rawValue)
+                } else {
+                    Text("—").foregroundStyle(.secondary)
+                }
+            case .extract:
+                if let fields = vm.extracted {
+                    VStack(alignment: .leading, spacing: 8) {
+                        LabeledContent("Invoice Number", value: fields.invoiceNumber)
+                        LabeledContent("Total USD", value: String(format: "%.2f", fields.totalUSD))
+                    }
+                } else {
+                    Text("—").foregroundStyle(.secondary)
+                }
+            }
+        }
+    }
+
+    @main
+    struct SwiftUIDemoApp: App {
+        var body: some Scene {
+            WindowGroup {
+                ContentView()
+            }
+        }
+    }
+
+#else
+
+    @main
+    enum SwiftUIDemoApp {
+        static func main() {
+            print("SwiftUIDemo requires macOS or iOS")
+        }
+    }
+
+#endif

--- a/Examples/iOS/CastDemo/.gitignore
+++ b/Examples/iOS/CastDemo/.gitignore
@@ -1,0 +1,7 @@
+*.xcodeproj
+xcuserdata/
+.swiftpm/
+Package.resolved
+.DS_Store
+build/
+DerivedData/

--- a/Examples/iOS/CastDemo/README.md
+++ b/Examples/iOS/CastDemo/README.md
@@ -4,7 +4,7 @@ A SwiftUI iOS demo of the [Cast](https://github.com/jaylann/Cast) Swift package.
 
 ## Prerequisites
 
-- Xcode 15+ (Swift 6.0)
+- Xcode 16+ (or Xcode 15 with an external Swift 6 toolchain)
 - An M-series Mac (MLX requires Apple Silicon)
 - iOS Simulator or a physical iOS 17+ device
 - [XcodeGen](https://github.com/yonaskolb/XcodeGen) for generating the Xcode project

--- a/Examples/iOS/CastDemo/README.md
+++ b/Examples/iOS/CastDemo/README.md
@@ -1,0 +1,36 @@
+# CastDemo (iOS)
+
+A SwiftUI iOS demo of the [Cast](https://github.com/jaylann/Cast) Swift package. Demonstrates the three primary modes — `cast()`, `classify()`, and `extract()` — with live-streaming partial results.
+
+## Prerequisites
+
+- Xcode 15+ (Swift 6.0)
+- An M-series Mac (MLX requires Apple Silicon)
+- iOS Simulator or a physical iOS 17+ device
+- [XcodeGen](https://github.com/yonaskolb/XcodeGen) for generating the Xcode project
+
+## Setup
+
+```bash
+# 1. Install XcodeGen (one-time)
+brew install xcodegen
+
+# 2. From this directory, generate the Xcode project
+cd Examples/iOS/CastDemo
+xcodegen generate
+
+# 3. Open in Xcode and run
+open CastDemo.xcodeproj
+```
+
+## First run
+
+The app downloads ~2 GB of model weights (Llama-3.2-3B-Instruct-4bit) on first launch. Run it on Wi-Fi, and budget for the download to complete before tapping Generate.
+
+## Why XcodeGen
+
+`project.pbxproj` is hand-edit-hostile and merge-conflict-prone, so we keep it out of git and regenerate it from `project.yml`. Anyone with `xcodegen` installed can produce the same project deterministically.
+
+## Looking for a faster smoke test?
+
+The macOS-only `SwiftUIDemo` executable (in `Examples/Sources/SwiftUIDemo/`) covers the same modes without needing Xcode — `swift run SwiftUIDemo` from the `Examples/` directory.

--- a/Examples/iOS/CastDemo/Sources/CastDemoApp.swift
+++ b/Examples/iOS/CastDemo/Sources/CastDemoApp.swift
@@ -1,0 +1,10 @@
+import SwiftUI
+
+@main
+struct CastDemoApp: App {
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+        }
+    }
+}

--- a/Examples/iOS/CastDemo/Sources/ContentView.swift
+++ b/Examples/iOS/CastDemo/Sources/ContentView.swift
@@ -1,0 +1,247 @@
+import Cast
+import Observation
+import SwiftUI
+
+enum DemoMode: String, CaseIterable, Identifiable {
+    case cast = "Cast"
+    case classify = "Classify"
+    case extract = "Extract"
+
+    var id: String {
+        rawValue
+    }
+}
+
+@MainActor
+@Observable
+final class DemoViewModel {
+    var modelID: String = "mlx-community/Llama-3.2-3B-Instruct-4bit"
+    var prompt: String = "Quick weeknight pasta in 20 minutes."
+    var sourceText: String = """
+    ACME Corp.
+    Invoice Number: INV-7421
+    Date: 2025-03-12
+    Total Due: $1,250.00 USD
+    """
+
+    var mode: DemoMode = .cast
+
+    var model: CastModel?
+    var isLoading: Bool = false
+    var isGenerating: Bool = false
+
+    var partialRecipe: Recipe.PartiallyGenerated?
+    var progress: Double = 0
+    var classification: Sentiment?
+    var extracted: InvoiceFields?
+    var errorMessage: String?
+
+    var generationTask: Task<Void, Never>?
+
+    var canGenerate: Bool {
+        model != nil && !isGenerating && !isLoading
+    }
+
+    func loadModel() {
+        guard !isLoading else { return }
+        isLoading = true
+        errorMessage = nil
+        let id = modelID
+        Task { [weak self] in
+            do {
+                let loaded = try await CastModel.load(id)
+                await MainActor.run {
+                    guard let self else { return }
+                    self.model = loaded
+                    self.isLoading = false
+                    // Cancel in-flight generation when the app backgrounds
+                    // so iOS doesn't kill us for holding the GPU.
+                    loaded.enableBackgroundSafety()
+                }
+            } catch {
+                await MainActor.run {
+                    guard let self else { return }
+                    self.errorMessage = "Load failed: \(error.localizedDescription)"
+                    self.isLoading = false
+                }
+            }
+        }
+    }
+
+    func generate() {
+        guard let model, !isGenerating else { return }
+        errorMessage = nil
+        partialRecipe = nil
+        classification = nil
+        extracted = nil
+        progress = 0
+        isGenerating = true
+
+        let mode = self.mode
+        let prompt = self.prompt
+        let sourceText = self.sourceText
+
+        generationTask = Task { [weak self] in
+            defer {
+                Task { @MainActor [weak self] in
+                    self?.isGenerating = false
+                }
+            }
+
+            do {
+                switch mode {
+                case .cast:
+                    for try await partial in model.castStream(prompt, as: Recipe.self) {
+                        let snapshot = partial.value
+                        let pct = partial.progress
+                        await MainActor.run { [weak self] in
+                            self?.partialRecipe = snapshot
+                            self?.progress = pct
+                        }
+                    }
+                case .classify:
+                    let result: Sentiment = try await model.classify(prompt)
+                    await MainActor.run { [weak self] in
+                        self?.classification = result
+                    }
+                case .extract:
+                    let fields: InvoiceFields = try await model.extract(
+                        from: sourceText,
+                        instruction: prompt
+                    )
+                    await MainActor.run { [weak self] in
+                        self?.extracted = fields
+                    }
+                }
+            } catch {
+                await MainActor.run { [weak self] in
+                    self?.errorMessage = error.localizedDescription
+                }
+            }
+        }
+    }
+
+    func cancel() {
+        model?.abortInFlight()
+        generationTask?.cancel()
+    }
+}
+
+struct ContentView: View {
+    @State private var vm = DemoViewModel()
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                Section("Model") {
+                    TextField("Model ID", text: $vm.modelID)
+                        .disabled(vm.isLoading || vm.model != nil)
+                        .autocorrectionDisabled()
+                        .textInputAutocapitalization(.never)
+                    HStack {
+                        Button(vm.model == nil ? "Load Model" : "Loaded") {
+                            vm.loadModel()
+                        }
+                        .disabled(vm.isLoading || vm.model != nil)
+                        Spacer()
+                        if vm.isLoading {
+                            ProgressView()
+                        }
+                    }
+                }
+
+                Section("Mode") {
+                    Picker("Mode", selection: $vm.mode) {
+                        ForEach(DemoMode.allCases) { m in
+                            Text(m.rawValue).tag(m)
+                        }
+                    }
+                    .pickerStyle(.segmented)
+                }
+
+                Section(vm.mode == .extract ? "Instruction" : "Prompt") {
+                    TextField("Prompt", text: $vm.prompt, axis: .vertical)
+                        .lineLimit(2 ... 5)
+                }
+
+                if vm.mode == .extract {
+                    Section("Source Text") {
+                        TextEditor(text: $vm.sourceText)
+                            .font(.body.monospaced())
+                            .frame(minHeight: 120)
+                    }
+                }
+
+                Section("Run") {
+                    HStack {
+                        Button("Generate") { vm.generate() }
+                            .buttonStyle(.borderedProminent)
+                            .disabled(!vm.canGenerate)
+                        Spacer()
+                        Button("Cancel") { vm.cancel() }
+                            .buttonStyle(.bordered)
+                            .disabled(!vm.isGenerating)
+                    }
+                }
+
+                Section("Output") {
+                    OutputView(vm: vm)
+                }
+
+                if let error = vm.errorMessage {
+                    Section {
+                        Text(error)
+                            .foregroundStyle(.red)
+                            .font(.callout)
+                    }
+                }
+            }
+            .navigationTitle("Cast Demo")
+        }
+    }
+}
+
+struct OutputView: View {
+    let vm: DemoViewModel
+
+    var body: some View {
+        switch vm.mode {
+        case .cast:
+            VStack(alignment: .leading, spacing: 8) {
+                ProgressView(value: vm.progress)
+                LabeledContent("Title") {
+                    Text(vm.partialRecipe?.title ?? "—")
+                        .foregroundStyle(vm.partialRecipe?.title == nil ? .secondary : .primary)
+                }
+                LabeledContent("Prep Minutes") {
+                    Text(vm.partialRecipe?.prepMinutes.map { "\($0) min" } ?? "—")
+                        .foregroundStyle(vm.partialRecipe?.prepMinutes == nil ? .secondary : .primary)
+                }
+                if let ingredients = vm.partialRecipe?.ingredients, !ingredients.isEmpty {
+                    LabeledContent("Ingredients") {
+                        VStack(alignment: .trailing) {
+                            ForEach(Array(ingredients.enumerated()), id: \.offset) { _, item in
+                                Text(item ?? "—")
+                            }
+                        }
+                    }
+                }
+            }
+        case .classify:
+            if let result = vm.classification {
+                LabeledContent("Sentiment", value: result.rawValue)
+            } else {
+                Text("—").foregroundStyle(.secondary)
+            }
+        case .extract:
+            if let fields = vm.extracted {
+                VStack(alignment: .leading, spacing: 8) {
+                    LabeledContent("Invoice Number", value: fields.invoiceNumber)
+                    LabeledContent("Total USD", value: String(format: "%.2f", fields.totalUSD))
+                }
+            } else {
+                Text("—").foregroundStyle(.secondary)
+            }
+        }
+    }
+}

--- a/Examples/iOS/CastDemo/Sources/ContentView.swift
+++ b/Examples/iOS/CastDemo/Sources/ContentView.swift
@@ -47,23 +47,21 @@ final class DemoViewModel {
         isLoading = true
         errorMessage = nil
         let id = modelID
+        // Task inherits MainActor isolation from the enclosing context,
+        // so we can mutate state directly without an inner MainActor.run hop.
         Task { [weak self] in
             do {
                 let loaded = try await CastModel.load(id)
-                await MainActor.run {
-                    guard let self else { return }
-                    self.model = loaded
-                    self.isLoading = false
-                    // Cancel in-flight generation when the app backgrounds
-                    // so iOS doesn't kill us for holding the GPU.
-                    loaded.enableBackgroundSafety()
-                }
+                guard let self else { return }
+                self.model = loaded
+                self.isLoading = false
+                // Cancel in-flight generation when the app backgrounds
+                // so iOS doesn't kill us for holding the GPU.
+                loaded.enableBackgroundSafety()
             } catch {
-                await MainActor.run {
-                    guard let self else { return }
-                    self.errorMessage = "Load failed: \(error.localizedDescription)"
-                    self.isLoading = false
-                }
+                guard let self else { return }
+                self.errorMessage = "Load failed: \(error.localizedDescription)"
+                self.isLoading = false
             }
         }
     }
@@ -82,47 +80,39 @@ final class DemoViewModel {
         let sourceText = self.sourceText
 
         generationTask = Task { [weak self] in
-            defer {
-                Task { @MainActor [weak self] in
-                    self?.isGenerating = false
-                }
-            }
+            // The enclosing Task inherits MainActor isolation, so defer runs
+            // synchronously on MainActor — no extra hop, no UX race window
+            // where a fast second tap sees stale isGenerating=true.
+            defer { self?.isGenerating = false }
 
             do {
                 switch mode {
                 case .cast:
                     for try await partial in model.castStream(prompt, as: Recipe.self) {
-                        let snapshot = partial.value
-                        let pct = partial.progress
-                        await MainActor.run { [weak self] in
-                            self?.partialRecipe = snapshot
-                            self?.progress = pct
-                        }
+                        self?.partialRecipe = partial.value
+                        self?.progress = partial.progress
                     }
                 case .classify:
                     let result: Sentiment = try await model.classify(prompt)
-                    await MainActor.run { [weak self] in
-                        self?.classification = result
-                    }
+                    self?.classification = result
                 case .extract:
                     let fields: InvoiceFields = try await model.extract(
                         from: sourceText,
                         instruction: prompt
                     )
-                    await MainActor.run { [weak self] in
-                        self?.extracted = fields
-                    }
+                    self?.extracted = fields
                 }
             } catch {
-                await MainActor.run { [weak self] in
-                    self?.errorMessage = error.localizedDescription
-                }
+                self?.errorMessage = error.localizedDescription
             }
         }
     }
 
     func cancel() {
-        model?.abortInFlight()
+        // castStream's continuation.onTermination already cancels the
+        // underlying generation when the local Task is cancelled, so we
+        // don't need to call abortInFlight() (which would also cancel
+        // unrelated in-flight calls on the same model).
         generationTask?.cancel()
     }
 }
@@ -198,6 +188,11 @@ struct ContentView: View {
             }
             .navigationTitle("Cast Demo")
         }
+        // Tear down any in-flight generation if the user navigates away
+        // — iOS background safety only fires on app-backgrounding, not
+        // on view disappearance, and we don't want to keep holding the
+        // GPU while writing into an unobserved view-model.
+        .onDisappear { vm.cancel() }
     }
 }
 
@@ -221,7 +216,7 @@ struct OutputView: View {
                     LabeledContent("Ingredients") {
                         VStack(alignment: .trailing) {
                             ForEach(Array(ingredients.enumerated()), id: \.offset) { _, item in
-                                Text(item ?? "—")
+                                Text(item)
                             }
                         }
                     }

--- a/Examples/iOS/CastDemo/Sources/DemoModels.swift
+++ b/Examples/iOS/CastDemo/Sources/DemoModels.swift
@@ -1,0 +1,26 @@
+import Cast
+
+@Castable
+struct Recipe {
+    @Description("Short, punchy title")
+    var title: String = ""
+
+    @MaxCount(8)
+    var ingredients: [String] = []
+
+    @CastRange(1 ... 60)
+    var prepMinutes: Int = 0
+}
+
+enum Sentiment: String, CastEnum, CaseIterable {
+    case positive, negative, neutral
+}
+
+@Castable
+struct InvoiceFields {
+    @Description("Invoice number from the document")
+    var invoiceNumber: String = ""
+
+    @Description("Total amount in USD")
+    var totalUSD: Double = 0
+}

--- a/Examples/iOS/CastDemo/Sources/DemoModels.swift
+++ b/Examples/iOS/CastDemo/Sources/DemoModels.swift
@@ -1,4 +1,6 @@
 import Cast
+import Collections
+import JSONSchema
 
 @Castable
 struct Recipe {

--- a/Examples/iOS/CastDemo/project.yml
+++ b/Examples/iOS/CastDemo/project.yml
@@ -1,0 +1,30 @@
+name: CastDemo
+options:
+  deploymentTarget:
+    iOS: "17.0"
+  bundleIdPrefix: com.example.cast
+  developmentLanguage: en
+packages:
+  Cast:
+    path: ../../..
+targets:
+  CastDemo:
+    type: application
+    platform: iOS
+    deploymentTarget: "17.0"
+    sources:
+      - path: Sources
+    dependencies:
+      - package: Cast
+        product: Cast
+    settings:
+      base:
+        SWIFT_VERSION: "6.0"
+        IPHONEOS_DEPLOYMENT_TARGET: "17.0"
+        TARGETED_DEVICE_FAMILY: "1,2"
+        INFOPLIST_KEY_UILaunchScreen_Generation: YES
+        INFOPLIST_KEY_UIApplicationSceneManifest_Generation: YES
+        INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad: "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight"
+        INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone: "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight"
+        INFOPLIST_KEY_NSAppTransportSecurity: ""
+        GENERATE_INFOPLIST_FILE: YES

--- a/Examples/iOS/CastDemo/project.yml
+++ b/Examples/iOS/CastDemo/project.yml
@@ -7,6 +7,12 @@ options:
 packages:
   Cast:
     path: ../../..
+  swift-json-schema:
+    url: https://github.com/petrukha-ivan/swift-json-schema.git
+    from: "2.0.2"
+  swift-collections:
+    url: https://github.com/apple/swift-collections.git
+    from: "1.3.0"
 targets:
   CastDemo:
     type: application
@@ -17,6 +23,10 @@ targets:
     dependencies:
       - package: Cast
         product: Cast
+      - package: swift-json-schema
+        product: JSONSchema
+      - package: swift-collections
+        product: Collections
     settings:
       base:
         SWIFT_VERSION: "6.0"
@@ -26,5 +36,4 @@ targets:
         INFOPLIST_KEY_UIApplicationSceneManifest_Generation: YES
         INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad: "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight"
         INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone: "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight"
-        INFOPLIST_KEY_NSAppTransportSecurity: ""
         GENERATE_INFOPLIST_FILE: YES

--- a/Sources/Cast/Cast.docc/Cast.md
+++ b/Sources/Cast/Cast.docc/Cast.md
@@ -50,6 +50,7 @@ invalid tokens during decoding — so the model can only emit JSON that matches.
 - <doc:PrepareWarmup>
 - <doc:Cancellation>
 - <doc:Streaming>
+- <doc:SwiftUIDemo>
 - <doc:CallerManagedLoading>
 - <doc:ErrorHandling>
 - <doc:ChatTemplates>

--- a/Sources/Cast/Cast.docc/Examples/SwiftUIDemo.md
+++ b/Sources/Cast/Cast.docc/Examples/SwiftUIDemo.md
@@ -1,3 +1,12 @@
+# SwiftUIDemo
+
+SwiftUI app demonstrating cast/classify/extract with live-streaming Recipe fields.
+
+## Source
+
+Full source: [Examples/Sources/SwiftUIDemo/main.swift](https://github.com/jaylann/Cast/blob/main/Examples/Sources/SwiftUIDemo/main.swift)
+
+```swift
 // What this shows: SwiftUI app demonstrating cast/classify/extract with live-streaming Recipe fields.
 
 #if os(macOS) || os(iOS)
@@ -299,3 +308,4 @@
     }
 
 #endif
+```


### PR DESCRIPTION
## Summary

Closes the long-standing #44 (deferred until streaming + cancellation shipped). Two demo surfaces:

- **macOS SwiftUI executable** at `Examples/Sources/SwiftUIDemo/main.swift` — built by Examples CI; runnable via `swift run SwiftUIDemo`. Quick `swift`-only smoke without Xcode.
- **iOS Xcode app** at `Examples/iOS/CastDemo/` — XcodeGen-driven (`project.yml` + sources, no committed `.xcodeproj`). Run `xcodegen generate` to materialize the project, open in Xcode, run on Simulator or device.

Both demonstrate:
- Loading a model with `CastModel.load(...)`
- Three modes via a `Picker`: `cast()` (Recipe), `classify()` (Sentiment), `extract()` (InvoiceFields)
- Live-streaming partial Recipe fields via `castStream()` with a progress bar
- Cancel button wired to `model.abortInFlight()` (#41)
- iOS demo additionally calls `enableBackgroundSafety()` on load

## Why two surfaces

- iOS apps can't ship as a Swift Package `.executableTarget` — they need an `.app` bundle, which only Xcode produces. A hand-written `project.pbxproj` is fragile, so the iOS demo uses XcodeGen (`brew install xcodegen` → `xcodegen generate`).
- The macOS `SwiftUIDemo` target gives Examples CI an automated build check on the SwiftUI + Cast wiring without needing xcodebuild infrastructure.

## Test Plan

- [x] `swift build` at repo root passes (Cast unchanged)
- [x] `scripts/generate-example-docs.sh` mirrors the new article (`Cast.docc/Examples/SwiftUIDemo.md`); kept generated, not committed (CI regenerates)
- [x] `xcodegen generate` succeeds on `Examples/iOS/CastDemo/project.yml`
- [ ] macOS Examples build: not verified locally — the path-package quirk in CLAUDE.md (worktree dir != "Cast" → SPM derives `'examples'` and rejects `package: "Cast"`). Trust `.github/workflows/examples.yml` to validate from the main `Cast/` checkout.
- [ ] iOS Xcode build: blocked by pre-existing Cast iOS Sendable issue — see #105. The demo code compiles, but `Cast` itself fails to build for iOS targets due to three `non-Sendable NSObjectProtocol` capture errors in `CastModel+Lifecycle.swift:108-110`. Filing #105 separately; this PR's iOS demo will build cleanly once #105 lands.
- [ ] Manual UX smoke on iOS Simulator (left for repo owner — model weights need a real device or Wi-Fi)

## Notes

- `Examples/iOS/CastDemo/.xcodeproj` is gitignored — regenerated from `project.yml` by XcodeGen.
- `Examples/Package.swift` keeps `JSONSchema`/`Collections` target deps on the new `SwiftUIDemo` target; PR #74 (re-exports) will sweep these repo-wide. If #74 lands first, this PR rebases with a trivial conflict resolution.
- iOS demo `DemoModels.swift` does NOT carry the explicit `import Collections` / `import JSONSchema` — when #74 lands they'd be redundant. The macOS executable keeps them for now since Examples CI builds today.

Closes #44