### PR TITLE
fix(stage): minor cleanup batch (#97, #98, #99, #100)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ GitHub Releases (auto-generated from squash-merged PR titles) remain the canonic
 
 ## [Unreleased]
 
+### Added
+
+- `CastModel.extract(from:as:instruction:…)` — extraction-flavored entrypoint.
+- `CastModel.castStream(...)` — `AsyncSequence` of `PartialResult<T>` for streaming partial decoding.
+
 ## [0.1.0] - 2026-04-30
 
 First public release. Cast ships as an Apache-2.0 Swift Package: type-safe structured output from any local LLM on Apple Silicon via constrained decoding.
@@ -15,12 +20,12 @@ First public release. Cast ships as an Apache-2.0 Swift Package: type-safe struc
 ### Added
 
 - `@Castable` macro that synthesizes JSON Schema, `Decodable`, and a `PartiallyGenerated` mirror from an annotated struct.
-- `CastModel` with `cast`, `castJSON`, `classify`, `extract`, and `castStream` entrypoints; `init(wrapping:configuration:)` for caller-managed `ModelContainer` lifetimes.
+- `CastModel` with `cast`, `castJSON`, and `classify` entrypoints; `init(wrapping:configuration:)` for caller-managed `ModelContainer` lifetimes.
 - Property wrappers covering schema constraints: `@MaxLength`/`@MinLength`, `@Count`/`@MaxCount`/`@MinCount`, `@CastRange`, `@Precision`, `@Pattern`, `@OneOf`, `@Description`, `@Examples`, `@Nullable`, `@DefaultValue`, `@Validator`.
 - `JSONSchema.excluding(fields:)` for dynamic schema modification at call time.
 - `CastModel.prepare(_:)` warm-up to pay grammar-compilation cost upfront.
 - `didGenerate` callback for cooperative cancellation; `abortInFlight()` plus iOS background-safety hooks (`enableBackgroundSafety()` / `disableBackgroundSafety()`).
-- DocC documentation site auto-generated from runnable `Examples/` snippets (9 example targets).
+- DocC documentation site auto-generated from runnable `Examples/` snippets.
 - README, MIGRATION guide, security policy, and contributing guide.
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,44 @@
+# Changelog
+
+All notable changes to Cast are documented here.
+
+The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+GitHub Releases (auto-generated from squash-merged PR titles) remain the canonical source per release; this file is the human-readable summary kept under git so users can read it offline.
+
+## [Unreleased]
+
+## [0.1.0] - 2026-04-30
+
+First public release. Cast ships as an Apache-2.0 Swift Package: type-safe structured output from any local LLM on Apple Silicon via constrained decoding.
+
+### Added
+
+- `@Castable` macro that synthesizes JSON Schema, `Decodable`, and a `PartiallyGenerated` mirror from an annotated struct.
+- `CastModel` with `cast`, `castJSON`, `classify`, `extract`, and `castStream` entrypoints; `init(wrapping:configuration:)` for caller-managed `ModelContainer` lifetimes.
+- Property wrappers covering schema constraints: `@MaxLength`/`@MinLength`, `@Count`/`@MaxCount`/`@MinCount`, `@CastRange`, `@Precision`, `@Pattern`, `@OneOf`, `@Description`, `@Examples`, `@Nullable`, `@DefaultValue`, `@Validator`.
+- `JSONSchema.excluding(fields:)` for dynamic schema modification at call time.
+- `CastModel.prepare(_:)` warm-up to pay grammar-compilation cost upfront.
+- `didGenerate` callback for cooperative cancellation; `abortInFlight()` plus iOS background-safety hooks (`enableBackgroundSafety()` / `disableBackgroundSafety()`).
+- DocC documentation site auto-generated from runnable `Examples/` snippets (9 example targets).
+- README, MIGRATION guide, security policy, and contributing guide.
+
+### Changed
+
+- License unified to **Apache-2.0** across the package, including vendored upstreams (`petrukha-ivan/mlx-swift-structured` and `mlc-ai/xgrammar`); attribution preserved in `NOTICE`.
+- Repository moved to a staged release model: `stage` is the integration branch and PR target, `main` is release-only and updated by `.github/workflows/release.yml`.
+
+### Fixed
+
+- `@Castable` now synthesizes `Decodable` conformance for the consumer.
+- `MLXStructured/LICENSE` is excluded from the SPM target so the build no longer warns about an unhandled file.
+- xgrammar pinned to `v0.1.34` with `tvm_ffi` python bindings excluded.
+
+### Infrastructure
+
+- Manual release workflow (`release.yml`) with semver validation, tag uniqueness check, and CI-green gate before fast-forwarding `stage` → `main`.
+- `pre-public-check.sh` safety scanner (secrets, gitleaks, fork-PR audit) for every visibility / history change.
+- CI skips MLX runtime tests on `macos-15` runners via the `.requiresMetal` Swift Testing trait.
+
+[Unreleased]: https://github.com/jaylann/Cast/compare/v0.1.0...HEAD
+[0.1.0]: https://github.com/jaylann/Cast/releases/tag/v0.1.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -68,7 +68,7 @@ Use descriptive branch names:
 | `CastModel+Timeout.swift` | internal cross-isolation glue (`withGenerationTimeout`, `withInFlightRegistration`) | new public API |
 | `CastModel+GPUSafety.swift` | Metal/MLX lifecycle plumbing (`cleanupGPU`, global error handler) | code that doesn't touch `MLX.Stream` / `Memory` |
 
-If a new method doesn't fit any existing surface, add a new `CastModel+<Surface>.swift` rather than overloading one of the above. The first line of every such file should be a 2–3 line `// File rationale: …` comment that states what it owns and what it doesn't.
+If a new method doesn't fit any existing surface, add a new `CastModel+<Surface>.swift` rather than overloading one of the above. The first line of every such file should be a short header `// File rationale: …` comment that states what it owns and what it doesn't.
 
 ## Pull Request Process
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,6 +55,21 @@ Use descriptive branch names:
 - Use Swift Testing framework (`import Testing`)
 - Macro changes need expansion tests using `assertMacroExpansion`
 
+## Picking a `CastModel+*.swift` file
+
+`Sources/Cast/API/` splits the `CastModel` surface across six extension files. Use the table below when you add a new method so it lands in the right one — the file each method lives in is its surface contract.
+
+| File | Owns | Don't put here |
+|---|---|---|
+| `CastModel+Generation.swift` | every blocking generation entrypoint: `cast`, `castJSON`, `classify` | streaming, extraction-flavored prompts |
+| `CastModel+Stream.swift` | `castStream` and partial-decode helpers | blocking generation |
+| `CastModel+Extract.swift` | `extract(from:as:instruction:…)` and future extraction-shaped APIs | unrelated prompt templates |
+| `CastModel+Lifecycle.swift` | `abortInFlight()`, iOS background-safety hooks | model load/unload (the core `CastModel` type) |
+| `CastModel+Timeout.swift` | internal cross-isolation glue (`withGenerationTimeout`, `withInFlightRegistration`) | new public API |
+| `CastModel+GPUSafety.swift` | Metal/MLX lifecycle plumbing (`cleanupGPU`, global error handler) | code that doesn't touch `MLX.Stream` / `Memory` |
+
+If a new method doesn't fit any existing surface, add a new `CastModel+<Surface>.swift` rather than overloading one of the above. The first line of every such file should be a 2–3 line `// File rationale: …` comment that states what it owns and what it doesn't.
+
 ## Pull Request Process
 
 1. Fork the repository

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -21,7 +21,7 @@ For each existing type you want to migrate, walk these in order:
 
 - [ ] **Is it a `struct`?** Classes, actors, and `enum` (other than raw-value via `CastEnum`) are not supported by `@Castable`. The macro emits a `requiresStruct` diagnostic for non-structs.
 - [ ] **Are all stored properties `Sendable`?** Closures, `class` references, `weak` refs, `NSObject` subclasses, and most `AnyObject`-typed values are not.
-- [ ] **Are all stored properties `Decodable`?** Primitives (`String`, `Int`, `Double`, `Float`, `Bool`), arrays of `Decodable`, optionals of `Decodable`, and other `@Castable` types are fine. Custom types with `init(from:)` are fine.
+- [ ] **Are all stored properties `Decodable`?** Primitives (`String`, `Int`, `Double`, `Float`, `Bool`), arrays of `Decodable`, optionals of `Decodable`, and other `@Castable` types are fine. Custom *user-defined* types with `init(from:)` are fine; Foundation value types (`Date`, `URL`, `UUID`, `Data`, `Decimal`) are covered separately below.
 - [ ] **Are nested types also `@Castable`** (or otherwise `Decodable`)?
 - [ ] **No bare Foundation value types as fields.** `Date`, `URL`, `UUID`, `Data`, `Decimal` raise a compile-time `unknownNonPrimitiveType` error in v1.0+. See the *Foundation types* section below for the two supported workarounds.
 - [ ] **No generics with unbounded type parameters.** The macro reads syntactic types and won't infer constraints; if you need `MyType<T>`, give it `<T: Decodable & Sendable>` and don't expect the macro to do that for you.
@@ -206,7 +206,7 @@ Other knobs:
 
 The `@Castable` macro recognizes a fixed set of primitives (`String`, `Int`, `Double`, `Float`, `Bool`, arrays of those, plus other `@Castable` structs). Foundation value types — `Date`, `URL`, `UUID`, `Data`, `Decimal` — are **not** primitives from the macro's perspective: it can't synthesize a JSON Schema or grammar for them.
 
-> **Breaking change in v1.0:** prior versions emitted a *warning* and let expansion proceed; the consumer's downstream compile error was `<TypeName>.PartiallyGenerated.PartiallyGenerated?` — cryptic and hard to trace. As of v1.0, an `unknownNonPrimitiveType` field is a compile **error** at the macro site so the diagnostic is what you see, not a chain reaction in synthesized code.
+> **Breaking change in the v1.0 line (currently on `stage`, not yet released):** prior versions emitted a *warning* and let expansion proceed; the consumer's downstream compile error was `<TypeName>.PartiallyGenerated?` — cryptic and hard to trace. As of v1.0, an `unknownNonPrimitiveType` field is a compile **error** at the macro site so the diagnostic is what you see, not a chain reaction in synthesized code.
 
 ### Workaround 1: pre-convert at the model boundary
 

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -21,8 +21,9 @@ For each existing type you want to migrate, walk these in order:
 
 - [ ] **Is it a `struct`?** Classes, actors, and `enum` (other than raw-value via `CastEnum`) are not supported by `@Castable`. The macro emits a `requiresStruct` diagnostic for non-structs.
 - [ ] **Are all stored properties `Sendable`?** Closures, `class` references, `weak` refs, `NSObject` subclasses, and most `AnyObject`-typed values are not.
-- [ ] **Are all stored properties `Decodable`?** `URL`, primitives, arrays of `Decodable`, optionals of `Decodable`, and other `@Castable` types are fine. Custom types with `init(from:)` are fine.
+- [ ] **Are all stored properties `Decodable`?** Primitives (`String`, `Int`, `Double`, `Float`, `Bool`), arrays of `Decodable`, optionals of `Decodable`, and other `@Castable` types are fine. Custom types with `init(from:)` are fine.
 - [ ] **Are nested types also `@Castable`** (or otherwise `Decodable`)?
+- [ ] **No bare Foundation value types as fields.** `Date`, `URL`, `UUID`, `Data`, `Decimal` raise a compile-time `unknownNonPrimitiveType` error in v1.0+. See the *Foundation types* section below for the two supported workarounds.
 - [ ] **No generics with unbounded type parameters.** The macro reads syntactic types and won't infer constraints; if you need `MyType<T>`, give it `<T: Decodable & Sendable>` and don't expect the macro to do that for you.
 
 If every box is ticked, `@Castable struct Foo { ... }` will compile and `model.cast(_, as: Foo.self)` will work.
@@ -198,6 +199,50 @@ Other knobs:
 - Bump `config.maxTokens`.
 - Trim your schema (smaller types decode faster, less risk of truncation).
 - Use `castJSON` and inspect the raw output to confirm the issue is truncation vs. a hallucinated field. `castJSON` never repairs — by contract, callers asked for raw bytes.
+
+---
+
+## 3. Foundation types
+
+The `@Castable` macro recognizes a fixed set of primitives (`String`, `Int`, `Double`, `Float`, `Bool`, arrays of those, plus other `@Castable` structs). Foundation value types — `Date`, `URL`, `UUID`, `Data`, `Decimal` — are **not** primitives from the macro's perspective: it can't synthesize a JSON Schema or grammar for them.
+
+> **Breaking change in v1.0:** prior versions emitted a *warning* and let expansion proceed; the consumer's downstream compile error was `<TypeName>.PartiallyGenerated.PartiallyGenerated?` — cryptic and hard to trace. As of v1.0, an `unknownNonPrimitiveType` field is a compile **error** at the macro site so the diagnostic is what you see, not a chain reaction in synthesized code.
+
+### Workaround 1: pre-convert at the model boundary
+
+Make the field a primitive that round-trips through JSON, and convert in your application code:
+
+```swift
+@Castable
+struct Event {
+    var whenISO8601: String = ""   // instead of Date
+    var idString: String = ""      // instead of UUID
+    var attachmentBase64: String = "" // instead of Data
+}
+
+let event: Event = try await model.cast("…")
+let when = ISO8601DateFormatter().date(from: event.whenISO8601)
+```
+
+This is the path most consumers take; it keeps the schema small and the prompt easy for the model to satisfy.
+
+### Workaround 2: wrap the Foundation type in a small `@Castable`
+
+If you genuinely want the field to read as `Date` at the call site, give the macro a struct it can synthesize:
+
+```swift
+@Castable
+struct ISODate {
+    var iso8601: String = ""
+}
+
+@Castable
+struct Event {
+    var when: ISODate = ISODate()
+}
+```
+
+Then derive a `Date` from `event.when.iso8601` at the call site.
 
 ---
 

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,0 +1,37 @@
+# Getting Support
+
+Thanks for using Cast! Here's where to go depending on what you need.
+
+## Bug reports
+
+Open a [bug report issue](https://github.com/jaylann/Cast/issues/new?template=bug_report.yml). Include:
+
+- A minimal reproducer (the smallest `@Castable` struct + prompt that triggers the failure).
+- The model id you loaded (e.g. `mlx-community/Llama-3.2-3B-Instruct-4bit`).
+- Swift / Xcode / macOS versions.
+- The full error or stack trace, including any `CastError` case.
+
+If you suspect a security vulnerability, **do not** file a public issue — see [SECURITY.md](SECURITY.md) for the private reporting process.
+
+## Feature requests
+
+Open a [feature request issue](https://github.com/jaylann/Cast/issues/new?template=feature_request.yml). Describe the use case, what you tried as a workaround, and whether you'd be willing to send a PR. Existing roadmap items live in the repo's milestones.
+
+## Usage questions
+
+For "how do I…" questions:
+
+1. Skim the [DocC documentation](https://swiftpackageindex.com/jaylann/Cast/documentation/cast) — most public APIs are exercised in the `Examples` articles.
+2. Read [MIGRATION.md](MIGRATION.md) if you're adapting an existing model type.
+3. Search [closed issues](https://github.com/jaylann/Cast/issues?q=is%3Aissue+is%3Aclosed) — many design questions have been answered there.
+4. If none of those help, [open an issue](https://github.com/jaylann/Cast/issues/new) and label it `question`.
+
+GitHub Discussions are not currently enabled; please use issues for now.
+
+## Contributing
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for setup, coding standards, and PR conventions.
+
+## Commercial support
+
+There is no paid support tier. Cast is maintained best-effort by [@jaylann](https://github.com/jaylann) under the [Apache-2.0 license](LICENSE).

--- a/Sources/Cast/API/CastModel+Extract.swift
+++ b/Sources/Cast/API/CastModel+Extract.swift
@@ -1,3 +1,8 @@
+// File rationale: text-extraction-flavored prompt builder that delegates to
+// `cast`. Owns `extract(from:as:instruction:…)` and any future extraction-
+// shaped entrypoints. Doesn't own: new generation modes or unrelated prompt
+// templates — those go in `CastModel+Generation.swift` or a new file.
+
 import Foundation
 import JSONSchema
 @preconcurrency import MLXLMCommon

--- a/Sources/Cast/API/CastModel+GPUSafety.swift
+++ b/Sources/Cast/API/CastModel+GPUSafety.swift
@@ -1,3 +1,9 @@
+// File rationale: Metal/MLX lifecycle plumbing.
+// Owns: the global MLX error handler bridge, `cleanupGPU()`,
+// `ensureErrorHandler()`, `checkAndClearMLXGlobalError()`.
+// Doesn't own: anything that doesn't touch `MLX.Stream` / `Memory` /
+// the global C error handler.
+
 import Foundation
 import MLX
 @preconcurrency import MLXLMCommon
@@ -8,10 +14,11 @@ import os
 /// Captures errors from MLX C++ scheduler threads where Swift error handlers aren't visible.
 private let mlxGlobalErrorLock = OSAllocatedUnfairLock(initialState: String?.none)
 
-private let globalMLXErrorHandler: @convention(c) (UnsafePointer<CChar>?, UnsafeMutableRawPointer?) -> Void = { message, _ in
-    let errorMessage = message.map { String(cString: $0) } ?? "Unknown MLX error"
-    mlxGlobalErrorLock.withLock { $0 = errorMessage }
-}
+private let globalMLXErrorHandler: @convention(c) (UnsafePointer<CChar>?, UnsafeMutableRawPointer?)
+    -> Void = { message, _ in
+        let errorMessage = message.map { String(cString: $0) } ?? "Unknown MLX error"
+        mlxGlobalErrorLock.withLock { $0 = errorMessage }
+    }
 
 private let _setupGlobalErrorHandler: Void = {
     setErrorHandler(globalMLXErrorHandler)
@@ -20,7 +27,6 @@ private let _setupGlobalErrorHandler: Void = {
 // MARK: - GPU Safety Extensions
 
 extension CastModel {
-
     static func ensureErrorHandler() {
         _ = _setupGlobalErrorHandler
     }

--- a/Sources/Cast/API/CastModel+Generation.swift
+++ b/Sources/Cast/API/CastModel+Generation.swift
@@ -1,3 +1,8 @@
+// File rationale: every blocking generation entrypoint on `CastModel`.
+// Owns: `cast(_:as:…)`, `castJSON(_:…)`, `classify(_:…)`.
+// Doesn't own: streaming (see `CastModel+Stream.swift`) or the
+// extraction-flavored prompt (see `CastModel+Extract.swift`).
+
 import Foundation
 import JSONSchema
 import MLX

--- a/Sources/Cast/API/CastModel+Lifecycle.swift
+++ b/Sources/Cast/API/CastModel+Lifecycle.swift
@@ -1,3 +1,9 @@
+// File rationale: in-flight cancellation and iOS app-lifecycle plumbing.
+// Owns: `abortInFlight()`, `enableBackgroundSafety()`/`disableBackgroundSafety()`,
+// and the iOS-only observer storage.
+// Doesn't own: model load/unload (`CastModel.swift` core) or GPU cleanup
+// (`CastModel+GPUSafety.swift`).
+
 import Foundation
 import MLX
 import os

--- a/Sources/Cast/API/CastModel+Stream.swift
+++ b/Sources/Cast/API/CastModel+Stream.swift
@@ -1,3 +1,7 @@
+// File rationale: streaming generation surface and its partial-decode helpers.
+// Owns: `castStream(_:as:…)`, `decodePartial`, `yieldTerminal`, `StreamBufferHolder`.
+// Doesn't own: blocking generation (see `CastModel+Generation.swift`).
+
 import Foundation
 import JSONSchema
 import MLX

--- a/Sources/Cast/API/CastModel+Timeout.swift
+++ b/Sources/Cast/API/CastModel+Timeout.swift
@@ -1,3 +1,9 @@
+// File rationale: internal cross-isolation glue shared by `+Generation` and
+// `+Stream`. Owns `withGenerationTimeout` (free function) and
+// `withInFlightRegistration` (extension method).
+// Doesn't own: any public API — this file only adds infrastructure consumed
+// by generation entrypoints.
+
 import Foundation
 
 /// Race a generation against a wall-clock timeout. When the timeout fires,

--- a/Sources/CastMacros/CastableDiagnostic.swift
+++ b/Sources/CastMacros/CastableDiagnostic.swift
@@ -36,7 +36,7 @@ enum CastableDiagnostic: DiagnosticMessage {
         case .precisionOnNonFloat:
             "@Precision can only be applied to Double or Float properties"
         case let .unknownNonPrimitiveType(typeName):
-            "'\(typeName)' is not a Cast-supported type. Wrap it in a small @Castable struct, or pre-convert to a primitive at the model boundary (e.g. ISO-8601 String for Date, raw bytes for Data). See the 'Foundation types' section of MIGRATION.md."
+            "'\(typeName)' is not a Cast-supported type. Wrap it in a small @Castable struct, or pre-convert to a primitive at the model boundary (e.g. ISO-8601 String for Date, Base64 String or `[UInt8]`/`[Int]` for Data). See the 'Foundation types' section of MIGRATION.md."
         }
     }
 
@@ -56,6 +56,14 @@ enum CastableDiagnostic: DiagnosticMessage {
     }
 
     var severity: DiagnosticSeverity {
-        .error
+        // Kept as a `switch self` even though every case currently maps to
+        // `.error`: this preserves the load-bearing structure for any future
+        // `.warning` case without requiring contributors to rediscover the
+        // pattern (and the matching `hasError` early-return guard in
+        // `CastableMacro.expansion`). See CLAUDE.md "Learnings" entry.
+        switch self {
+        default:
+            .error
+        }
     }
 }

--- a/Sources/CastMacros/CastableDiagnostic.swift
+++ b/Sources/CastMacros/CastableDiagnostic.swift
@@ -9,11 +9,12 @@ enum CastableDiagnostic: DiagnosticMessage {
     case conflictingLengths
     case patternOnNonString
     case precisionOnNonFloat
-    /// Warns when a field's declared type isn't a known primitive and isn't
-    /// recognizably another `@Castable` struct (Foundation value types like
-    /// `Date`, `URL`, `UUID`, `Data`, `Decimal`). The macro will still project
-    /// it as `<TypeName>.PartiallyGenerated?` in the synthesized mirror; the
-    /// consumer must supply that conformance themselves or wrap the field.
+    /// Errors when a field's declared type isn't a known primitive and isn't
+    /// another `@Castable` struct (Foundation value types like `Date`, `URL`,
+    /// `UUID`, `Data`, `Decimal`). Was a warning pre-v1.0; promoted to error
+    /// because the synthesized mirror would otherwise produce a cryptic
+    /// `<TypeName>.PartiallyGenerated?` compile error downstream — surfacing
+    /// the diagnostic at the call site is friendlier.
     case unknownNonPrimitiveType(typeName: String)
 
     var message: String {
@@ -35,7 +36,7 @@ enum CastableDiagnostic: DiagnosticMessage {
         case .precisionOnNonFloat:
             "@Precision can only be applied to Double or Float properties"
         case let .unknownNonPrimitiveType(typeName):
-            "'\(typeName)' is not a Cast-supported primitive; the synthesized PartiallyGenerated mirror will project this field as '\(typeName).PartiallyGenerated?' and will fail to compile unless '\(typeName)' is itself @Castable. Consider wrapping it in a small @Castable struct or pre-converting to a primitive (e.g. ISO-8601 String for dates)."
+            "'\(typeName)' is not a Cast-supported type. Wrap it in a small @Castable struct, or pre-convert to a primitive at the model boundary (e.g. ISO-8601 String for Date, raw bytes for Data). See the 'Foundation types' section of MIGRATION.md."
         }
     }
 
@@ -55,11 +56,6 @@ enum CastableDiagnostic: DiagnosticMessage {
     }
 
     var severity: DiagnosticSeverity {
-        switch self {
-        case .unknownNonPrimitiveType:
-            .warning
-        default:
-            .error
-        }
+        .error
     }
 }

--- a/Tests/CastMacroTests/CastDiagnosticTests.swift
+++ b/Tests/CastMacroTests/CastDiagnosticTests.swift
@@ -168,9 +168,9 @@ struct CastDiagnosticTests {
         )
     }
 
-    @Test("Foundation Date field emits unknownNonPrimitiveType warning but expansion still succeeds")
+    @Test("Foundation Date field emits unknownNonPrimitiveType error and blocks expansion")
     func unknownFoundationType() {
-        let warning = CastableDiagnostic.unknownNonPrimitiveType(typeName: "Date")
+        let error = CastableDiagnostic.unknownNonPrimitiveType(typeName: "Date")
         assertMacroExpansion(
             """
             @Castable
@@ -181,28 +181,10 @@ struct CastDiagnosticTests {
             expandedSource: """
             struct Event {
                 var when: Date
-
-                static let castSchema: JSONSchema = .object(
-                    properties: OrderedDictionary(dictionaryLiteral:
-                        ("when", Date.castSchema)
-                    ),
-                    required: ["when"],
-                    additionalProperties: .boolean(false)
-                )
-
-                init() {
-                }
-
-                struct PartiallyGenerated: Sendable, Decodable {
-                    var when: Date.PartiallyGenerated?
-                }
-            }
-
-            extension Event: Castable, Decodable {
             }
             """,
             diagnostics: [
-                DiagnosticSpec(message: warning.message, line: 3, column: 5, severity: .warning)
+                DiagnosticSpec(message: error.message, line: 3, column: 5, severity: .error)
             ],
             macros: testMacros
         )

--- a/Tests/CastTests/SchemaExcludingTests.swift
+++ b/Tests/CastTests/SchemaExcludingTests.swift
@@ -1,17 +1,16 @@
-import Foundation
-import Testing
-import JSONSchema
-import Collections
-
 @testable import Cast
+import Collections
+import Foundation
+import JSONSchema
+import Testing
 
 @Suite("JSONSchema.excluding")
 struct SchemaExcludingTests {
-
     @Test("excluding removes fields from properties")
     func removesFields() throws {
         let schema = JSONSchema.object(
-            properties: OrderedDictionary(dictionaryLiteral:
+            properties: OrderedDictionary(
+                dictionaryLiteral:
                 ("name", JSONSchema.string()),
                 ("age", JSONSchema.integer()),
                 ("email", JSONSchema.string())
@@ -32,7 +31,8 @@ struct SchemaExcludingTests {
     @Test("excluding removes fields from required array")
     func removesFromRequired() throws {
         let schema = JSONSchema.object(
-            properties: OrderedDictionary(dictionaryLiteral:
+            properties: OrderedDictionary(
+                dictionaryLiteral:
                 ("name", JSONSchema.string()),
                 ("age", JSONSchema.integer()),
                 ("email", JSONSchema.string())
@@ -53,7 +53,8 @@ struct SchemaExcludingTests {
     @Test("excluding multiple fields")
     func multipleFields() throws {
         let schema = JSONSchema.object(
-            properties: OrderedDictionary(dictionaryLiteral:
+            properties: OrderedDictionary(
+                dictionaryLiteral:
                 ("a", JSONSchema.string()),
                 ("b", JSONSchema.integer()),
                 ("c", JSONSchema.number()),
@@ -77,7 +78,8 @@ struct SchemaExcludingTests {
     @Test("excluding empty set returns equivalent schema")
     func emptyExclusion() throws {
         let schema = JSONSchema.object(
-            properties: OrderedDictionary(dictionaryLiteral:
+            properties: OrderedDictionary(
+                dictionaryLiteral:
                 ("name", JSONSchema.string()),
                 ("age", JSONSchema.integer())
             ),
@@ -94,7 +96,8 @@ struct SchemaExcludingTests {
     @Test("excluding preserves field constraints")
     func preservesConstraints() throws {
         let schema = JSONSchema.object(
-            properties: OrderedDictionary(dictionaryLiteral:
+            properties: OrderedDictionary(
+                dictionaryLiteral:
                 ("title", JSONSchema.string(maxLength: 100)),
                 ("rating", JSONSchema.integer(minimum: 1, maximum: 10)),
                 ("extra", JSONSchema.string())
@@ -118,7 +121,8 @@ struct SchemaExcludingTests {
     @Test("excluding all required fields removes required key")
     func allRequiredExcluded() throws {
         let schema = JSONSchema.object(
-            properties: OrderedDictionary(dictionaryLiteral:
+            properties: OrderedDictionary(
+                dictionaryLiteral:
                 ("a", JSONSchema.string()),
                 ("b", JSONSchema.string())
             ),
@@ -150,7 +154,8 @@ struct SchemaExcludingTests {
     @Test("excluding works with enum fields")
     func enumFields() throws {
         let schema = JSONSchema.object(
-            properties: OrderedDictionary(dictionaryLiteral:
+            properties: OrderedDictionary(
+                dictionaryLiteral:
                 ("status", JSONSchema.enum(values: [.string("active"), .string("inactive")])),
                 ("name", JSONSchema.string())
             ),
@@ -165,6 +170,178 @@ struct SchemaExcludingTests {
         #expect(props?["name"] != nil)
     }
 
+    // MARK: - Regression locks
+
+    //
+    // These tests exist to fail loudly if the underlying JSON-string round-trip
+    // in `JSONSchema.excluding(fields:)` ever drifts (upstream `JSONSchema`
+    // bumps, encoder shape changes, regex-strip semantics). They lock structural
+    // properties — nested traversal, key adjacency, idempotence — that the
+    // behavioral tests above don't cover.
+
+    @Test("excluding preserves nested object property schemas")
+    func preservesNestedObject() throws {
+        let address = JSONSchema.object(
+            properties: OrderedDictionary(
+                dictionaryLiteral:
+                ("street", JSONSchema.string()),
+                ("zip", JSONSchema.string())
+            ),
+            required: ["street", "zip"]
+        )
+        let schema = JSONSchema.object(
+            properties: OrderedDictionary(
+                dictionaryLiteral:
+                ("name", JSONSchema.string()),
+                ("address", address)
+            ),
+            required: ["name", "address"],
+            additionalProperties: .boolean(false)
+        )
+
+        let reduced = schema.excluding(fields: ["name"])
+        let json = try schemaDict(reduced)
+        let props = json["properties"] as? [String: Any]
+        let nested = props?["address"] as? [String: Any]
+        let nestedProps = nested?["properties"] as? [String: Any]
+        let nestedRequired = nested?["required"] as? [String] ?? []
+
+        #expect(props?["name"] == nil)
+        #expect(nestedProps?["street"] != nil)
+        #expect(nestedProps?["zip"] != nil)
+        #expect(nestedRequired.contains("street"))
+        #expect(nestedRequired.contains("zip"))
+    }
+
+    @Test("excluding preserves array item schemas")
+    func preservesArrayItems() throws {
+        let item = JSONSchema.object(
+            properties: OrderedDictionary(
+                dictionaryLiteral:
+                ("name", JSONSchema.string()),
+                ("qty", JSONSchema.integer())
+            ),
+            required: ["name", "qty"]
+        )
+        let schema = JSONSchema.object(
+            properties: OrderedDictionary(
+                dictionaryLiteral:
+                ("title", JSONSchema.string()),
+                ("items", JSONSchema.array(items: item))
+            ),
+            required: ["title", "items"],
+            additionalProperties: .boolean(false)
+        )
+
+        let reduced = schema.excluding(fields: ["title"])
+        let json = try schemaDict(reduced)
+        let props = json["properties"] as? [String: Any]
+        let items = props?["items"] as? [String: Any]
+        let itemSchema = items?["items"] as? [String: Any]
+        let itemProps = itemSchema?["properties"] as? [String: Any]
+
+        #expect(props?["title"] == nil)
+        #expect(itemProps?["name"] != nil)
+        #expect(itemProps?["qty"] != nil)
+    }
+
+    @Test("excluding preserves additionalProperties: false")
+    func preservesAdditionalProperties() throws {
+        let schema = JSONSchema.object(
+            properties: OrderedDictionary(
+                dictionaryLiteral:
+                ("a", JSONSchema.string()),
+                ("b", JSONSchema.integer())
+            ),
+            required: ["a", "b"],
+            additionalProperties: .boolean(false)
+        )
+
+        let reduced = schema.excluding(fields: ["a"])
+        let json = try schemaDict(reduced)
+
+        #expect(json["additionalProperties"] as? Bool == false)
+    }
+
+    @Test("excluding survives schemas that emit __N__ deduplication markers")
+    func survivesDeduplicationMarkers() throws {
+        // The upstream JSONSchema encoder emits `__N__` substrings to
+        // deduplicate structurally-identical sub-schemas. `excluding` strips
+        // them in its intermediate dict via regex before `JSONSerialization`
+        // would otherwise reject them. Reusing `inner` in two sibling
+        // positions reliably triggers the marker emission; the test locks
+        // that the round-trip still produces a usable schema with the
+        // expected remaining fields.
+        let inner = JSONSchema.object(
+            properties: OrderedDictionary(
+                dictionaryLiteral:
+                ("x", JSONSchema.string()),
+                ("y", JSONSchema.integer())
+            ),
+            required: ["x", "y"]
+        )
+        let schema = JSONSchema.object(
+            properties: OrderedDictionary(
+                dictionaryLiteral:
+                ("a", inner),
+                ("b", JSONSchema.array(items: inner)),
+                ("c", JSONSchema.string())
+            ),
+            required: ["a", "b", "c"],
+            additionalProperties: .boolean(false)
+        )
+
+        let reduced = schema.excluding(fields: ["c"])
+        let dict = try schemaDict(reduced)
+        let props = dict["properties"] as? [String: Any]
+
+        #expect(props?["a"] != nil)
+        #expect(props?["b"] != nil)
+        #expect(props?["c"] == nil)
+    }
+
+    @Test("excluding twice yields the same property set as excluding once")
+    func idempotent() throws {
+        // Idempotence at the *property-set* level. Byte-level equality is
+        // not guaranteed because the round-trip goes through `[String: Any]`,
+        // whose iteration order is not stable across the second pass.
+        let schema = JSONSchema.object(
+            properties: OrderedDictionary(
+                dictionaryLiteral:
+                ("a", JSONSchema.string()),
+                ("b", JSONSchema.integer()),
+                ("c", JSONSchema.boolean())
+            ),
+            required: ["a", "b", "c"],
+            additionalProperties: .boolean(false)
+        )
+
+        let once = schema.excluding(fields: ["b"])
+        let twice = once.excluding(fields: ["b"])
+
+        let onceProps = try (schemaDict(once))["properties"] as? [String: Any] ?? [:]
+        let twiceProps = try (schemaDict(twice))["properties"] as? [String: Any] ?? [:]
+        let onceRequired = try Set(schemaDict(once)["required"] as? [String] ?? [])
+        let twiceRequired = try Set(schemaDict(twice)["required"] as? [String] ?? [])
+
+        #expect(Set(onceProps.keys) == Set(twiceProps.keys))
+        #expect(onceProps.keys.sorted() == ["a", "c"])
+        #expect(onceRequired == twiceRequired)
+    }
+
+    @Test("excluding non-object schema returns input unchanged")
+    func nonObjectSchemaUnchanged() throws {
+        let schema = JSONSchema.string(maxLength: 100)
+        let reduced = schema.excluding(fields: ["anything"])
+
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+        let originalData = try encoder.encode(schema)
+        let reducedData = try encoder.encode(reduced)
+
+        #expect(originalData == reducedData)
+    }
+
     // MARK: - Helpers
 
     private func schemaDict(_ schema: JSONSchema) throws -> [String: Any] {
@@ -172,7 +349,8 @@ struct SchemaExcludingTests {
         let sanitized = String(decoding: data, as: UTF8.self)
             .replacingOccurrences(of: "__[0-9]+__", with: "", options: .regularExpression)
         guard let jsonData = sanitized.data(using: .utf8),
-              let dict = try JSONSerialization.jsonObject(with: jsonData) as? [String: Any] else {
+              let dict = try JSONSerialization.jsonObject(with: jsonData) as? [String: Any]
+        else {
             throw TestError.invalidSchema
         }
         return dict

--- a/Tests/CastTests/SchemaExcludingTests.swift
+++ b/Tests/CastTests/SchemaExcludingTests.swift
@@ -202,11 +202,14 @@ struct SchemaExcludingTests {
         let reduced = schema.excluding(fields: ["name"])
         let json = try schemaDict(reduced)
         let props = json["properties"] as? [String: Any]
+        let topRequired = json["required"] as? [String] ?? []
         let nested = props?["address"] as? [String: Any]
         let nestedProps = nested?["properties"] as? [String: Any]
         let nestedRequired = nested?["required"] as? [String] ?? []
 
         #expect(props?["name"] == nil)
+        #expect(!topRequired.contains("name"))
+        #expect(topRequired.contains("address"))
         #expect(nestedProps?["street"] != nil)
         #expect(nestedProps?["zip"] != nil)
         #expect(nestedRequired.contains("street"))
@@ -263,15 +266,18 @@ struct SchemaExcludingTests {
         #expect(json["additionalProperties"] as? Bool == false)
     }
 
-    @Test("excluding survives schemas that emit __N__ deduplication markers")
-    func survivesDeduplicationMarkers() throws {
-        // The upstream JSONSchema encoder emits `__N__` substrings to
-        // deduplicate structurally-identical sub-schemas. `excluding` strips
-        // them in its intermediate dict via regex before `JSONSerialization`
-        // would otherwise reject them. Reusing `inner` in two sibling
-        // positions reliably triggers the marker emission; the test locks
-        // that the round-trip still produces a usable schema with the
-        // expected remaining fields.
+    @Test("top-level field exclusion preserves siblings on schemas with shared sub-schemas")
+    func preservesSiblingsWithSharedSubSchemas() throws {
+        // Reuses `inner` in two sibling positions, which reliably triggers
+        // the upstream JSONSchema encoder's `__N__` deduplication markers in
+        // the raw JSON. `JSONSchema.excluding` strips those markers in its
+        // intermediate JSON-string pass.
+        //
+        // Note: the `schemaDict(_:)` helper below ALSO regex-strips `__N__`
+        // before `JSONSerialization`, so this test does not lock
+        // marker-handling inside `excluding` itself — it only locks that
+        // top-level field exclusion preserves the surviving siblings when
+        // the schema graph contains shared sub-schemas.
         let inner = JSONSchema.object(
             properties: OrderedDictionary(
                 dictionaryLiteral:
@@ -327,6 +333,7 @@ struct SchemaExcludingTests {
         #expect(Set(onceProps.keys) == Set(twiceProps.keys))
         #expect(onceProps.keys.sorted() == ["a", "c"])
         #expect(onceRequired == twiceRequired)
+        #expect(!onceRequired.contains("b"))
     }
 
     @Test("excluding non-object schema returns input unchanged")


### PR DESCRIPTION
## Summary

Four small "minor" issues batched into one PR ahead of v1.0 polish:

- **#97** — Add `CHANGELOG.md` (Keep-a-Changelog format, 0.1.0 backfill) and `SUPPORT.md` (GitHub-recommended template). Both files are missing from the repo and are standard for OSS projects on the GitHub Community Standards page.
- **#98** — Add a 2–3 line `// File rationale:` header to each of the six `Sources/Cast/API/CastModel+*.swift` extensions stating the surface it owns and what doesn't belong. Add a "Picking a CastModel+*.swift file" table to `CONTRIBUTING.md`. No code change. Decision: keep `+Timeout.swift` separate (it's used by both `+Generation` and `+Stream`; folding would re-introduce coupling).
- **#99** — Add six regression tests to `SchemaExcludingTests` that lock the structural behavior of the JSON-string round-trip in `JSONSchema.excluding(fields:)` so future `swift-json-schema` upstream bumps surface as test failures, not silent shape drift. Implementation rewrite is deferred per the issue body until upstream exposes a public AST hook.
- **#100** — Promote `unknownNonPrimitiveType` from warning to **error**. Bare `Date`/`URL`/`UUID`/`Data`/`Decimal` fields used to emit a warning and let expansion proceed, producing a cryptic downstream `<TypeName>.PartiallyGenerated.PartiallyGenerated?` compile error. Now surfaced at the macro site. New `MIGRATION.md §3 — Foundation types` documents the two supported workarounds.

⚠️ **Breaking** — `@Castable struct Foo { var when: Date }` no longer compiles. Migrate per `MIGRATION.md §3`.

## Test Plan

- [x] `swift build` — succeeds (only pre-existing deprecation warnings in `MLX.setErrorHandler`).
- [x] `swift test --filter SchemaExcludingTests` — 14 tests pass (8 existing + 6 new).
- [x] `swift test --filter CastMacroTests` — 26 tests pass; the renamed `unknownNonPrimitiveType` test asserts `.error` severity and a no-expansion outcome.
- [x] `CI=true swift test` — full suite (206 tests) passes.

Closes #97
Closes #98
Closes #99
Closes #100