### PR TITLE
refactor(tests): replace Mirror force-unwraps with #require (#96)

### DIFF
--- a/Tests/CastTests/NewWrapperTests.swift
+++ b/Tests/CastTests/NewWrapperTests.swift
@@ -1,10 +1,9 @@
+@testable import Cast
 import Foundation
 import JSONSchema
 import Testing
 
-@testable import Cast
-
-fileprivate struct NewWrappersStruct {
+private struct NewWrappersStruct {
     @Pattern("[a-z]+") var code: String = ""
     @Precision(2) var price: Double = 0.0
     @Count(3) var topPicks: [String] = []
@@ -12,59 +11,57 @@ fileprivate struct NewWrappersStruct {
     @DefaultValue("N/A") var company: String = ""
 }
 
-fileprivate struct CastableNewWrappers: Castable {
+private struct CastableNewWrappers: Castable {
     @Pattern("[a-z]+") var code: String = ""
     @Precision(2) var price: Double = 0.0
     @Count(3) var picks: [String] = []
     @Nullable var nick: String = ""
     @DefaultValue("N/A") var company: String = ""
-    init() {}
 }
 
 @Suite("NewPropertyWrappers")
 struct NewWrapperTests {
-
-    fileprivate let instance = NewWrappersStruct()
+    private let instance = NewWrappersStruct()
 
     // MARK: - Mirror constraint detection
 
     @Test("Pattern constraint readable via Mirror")
-    func patternMirror() {
+    func patternMirror() throws {
         let mirror = Mirror(reflecting: instance)
-        let child = mirror.children.first { $0.label == "_code" }!
-        let wrapper = child.value as! Pattern<String>
+        let child = try #require(mirror.children.first { $0.label == "_code" })
+        let wrapper = try #require(child.value as? Pattern<String>)
         #expect(wrapper.pattern == "[a-z]+")
     }
 
     @Test("Precision constraint readable via Mirror")
-    func precisionMirror() {
+    func precisionMirror() throws {
         let mirror = Mirror(reflecting: instance)
-        let child = mirror.children.first { $0.label == "_price" }!
-        let wrapper = child.value as! Precision<Double>
+        let child = try #require(mirror.children.first { $0.label == "_price" })
+        let wrapper = try #require(child.value as? Precision<Double>)
         #expect(wrapper.precision == 2)
     }
 
     @Test("Count constraint readable via Mirror")
-    func countMirror() {
+    func countMirror() throws {
         let mirror = Mirror(reflecting: instance)
-        let child = mirror.children.first { $0.label == "_topPicks" }!
-        let wrapper = child.value as! Count<[String]>
+        let child = try #require(mirror.children.first { $0.label == "_topPicks" })
+        let wrapper = try #require(child.value as? Count<[String]>)
         #expect(wrapper.count == 3)
     }
 
     @Test("Nullable constraint readable via Mirror")
-    func nullableMirror() {
+    func nullableMirror() throws {
         let mirror = Mirror(reflecting: instance)
-        let child = mirror.children.first { $0.label == "_nickname" }!
-        let wrapper = child.value as! Nullable<String>
+        let child = try #require(mirror.children.first { $0.label == "_nickname" })
+        let wrapper = try #require(child.value as? Nullable<String>)
         #expect(wrapper.isNullable == true)
     }
 
     @Test("DefaultValue constraint readable via Mirror")
-    func defaultValueMirror() {
+    func defaultValueMirror() throws {
         let mirror = Mirror(reflecting: instance)
-        let child = mirror.children.first { $0.label == "_company" }!
-        let wrapper = child.value as! DefaultValue<String>
+        let child = try #require(mirror.children.first { $0.label == "_company" })
+        let wrapper = try #require(child.value as? DefaultValue<String>)
         #expect(wrapper.defaultValue == "N/A")
     }
 

--- a/Tests/CastTests/PropertyWrapperTests.swift
+++ b/Tests/CastTests/PropertyWrapperTests.swift
@@ -5,7 +5,7 @@ import Testing
 struct TestStruct {
     @MaxLength(100) var title: String = ""
     @MinLength(1) var name: String = ""
-    @CastRange(1 ... 10) var rating: Int = 0
+    @CastRange(1...10) var rating: Int = 0
     @MaxCount(5) var tags: [String] = []
     @MinCount(1) var items: [String] = []
     @OneOf(["USD", "EUR"]) var currency: String = ""

--- a/Tests/CastTests/PropertyWrapperTests.swift
+++ b/Tests/CastTests/PropertyWrapperTests.swift
@@ -1,12 +1,11 @@
+@testable import Cast
 import Foundation
 import Testing
-
-@testable import Cast
 
 struct TestStruct {
     @MaxLength(100) var title: String = ""
     @MinLength(1) var name: String = ""
-    @CastRange(1...10) var rating: Int = 0
+    @CastRange(1 ... 10) var rating: Int = 0
     @MaxCount(5) var tags: [String] = []
     @MinCount(1) var items: [String] = []
     @OneOf(["USD", "EUR"]) var currency: String = ""
@@ -16,73 +15,72 @@ struct TestStruct {
 
 @Suite("PropertyWrappers")
 struct PropertyWrapperTests {
-
     let instance = TestStruct()
 
     // MARK: - Mirror constraint detection
 
     @Test("MaxLength constraint readable via Mirror")
-    func maxLengthMirror() {
+    func maxLengthMirror() throws {
         let mirror = Mirror(reflecting: instance)
-        let child = mirror.children.first { $0.label == "_title" }!
-        let wrapper = child.value as! MaxLength<String>
+        let child = try #require(mirror.children.first { $0.label == "_title" })
+        let wrapper = try #require(child.value as? MaxLength<String>)
         #expect(wrapper.maxLength == 100)
     }
 
     @Test("MinLength constraint readable via Mirror")
-    func minLengthMirror() {
+    func minLengthMirror() throws {
         let mirror = Mirror(reflecting: instance)
-        let child = mirror.children.first { $0.label == "_name" }!
-        let wrapper = child.value as! MinLength<String>
+        let child = try #require(mirror.children.first { $0.label == "_name" })
+        let wrapper = try #require(child.value as? MinLength<String>)
         #expect(wrapper.minLength == 1)
     }
 
     @Test("CastRange constraint readable via Mirror")
-    func castRangeMirror() {
+    func castRangeMirror() throws {
         let mirror = Mirror(reflecting: instance)
-        let child = mirror.children.first { $0.label == "_rating" }!
-        let wrapper = child.value as! CastRange<Int, Int>
+        let child = try #require(mirror.children.first { $0.label == "_rating" })
+        let wrapper = try #require(child.value as? CastRange<Int, Int>)
         #expect(wrapper.lowerBound == 1)
         #expect(wrapper.upperBound == 10)
     }
 
     @Test("MaxCount constraint readable via Mirror")
-    func maxCountMirror() {
+    func maxCountMirror() throws {
         let mirror = Mirror(reflecting: instance)
-        let child = mirror.children.first { $0.label == "_tags" }!
-        let wrapper = child.value as! MaxCount<[String]>
+        let child = try #require(mirror.children.first { $0.label == "_tags" })
+        let wrapper = try #require(child.value as? MaxCount<[String]>)
         #expect(wrapper.maxCount == 5)
     }
 
     @Test("MinCount constraint readable via Mirror")
-    func minCountMirror() {
+    func minCountMirror() throws {
         let mirror = Mirror(reflecting: instance)
-        let child = mirror.children.first { $0.label == "_items" }!
-        let wrapper = child.value as! MinCount<[String]>
+        let child = try #require(mirror.children.first { $0.label == "_items" })
+        let wrapper = try #require(child.value as? MinCount<[String]>)
         #expect(wrapper.minCount == 1)
     }
 
     @Test("OneOf constraint readable via Mirror")
-    func oneOfMirror() {
+    func oneOfMirror() throws {
         let mirror = Mirror(reflecting: instance)
-        let child = mirror.children.first { $0.label == "_currency" }!
-        let wrapper = child.value as! OneOf<String>
+        let child = try #require(mirror.children.first { $0.label == "_currency" })
+        let wrapper = try #require(child.value as? OneOf<String>)
         #expect(wrapper.values == ["USD", "EUR"])
     }
 
     @Test("Description constraint readable via Mirror")
-    func descriptionMirror() {
+    func descriptionMirror() throws {
         let mirror = Mirror(reflecting: instance)
-        let child = mirror.children.first { $0.label == "_summary" }!
-        let wrapper = child.value as! Description<String>
+        let child = try #require(mirror.children.first { $0.label == "_summary" })
+        let wrapper = try #require(child.value as? Description<String>)
         #expect(wrapper.descriptionText == "A description")
     }
 
     @Test("Examples constraint readable via Mirror")
-    func examplesMirror() {
+    func examplesMirror() throws {
         let mirror = Mirror(reflecting: instance)
-        let child = mirror.children.first { $0.label == "_review" }!
-        let wrapper = child.value as! Examples<String>
+        let child = try #require(mirror.children.first { $0.label == "_review" })
+        let wrapper = try #require(child.value as? Examples<String>)
         #expect(wrapper.examples == ["Good", "Bad"])
     }
 


### PR DESCRIPTION
## Summary

- Replaces ~17 `mirror.children.first { ... }\!` / `as\!` force-unwrap patterns in `PropertyWrapperTests` and `NewWrapperTests` with `try #require(...)`.
- Test failure mode is now a useful Swift Testing diagnostic (with the wrapper name and label being looked up), not a bare trap.
- Test bodies are unchanged; only signatures gain `throws`.

## Scope

- `Tests/CastTests/PropertyWrapperTests.swift` — 8 mirror-introspection tests rewritten.
- `Tests/CastTests/NewWrapperTests.swift` — 5 mirror-introspection tests rewritten.
- `Tests/CastTests/ValidatorTests.swift::mirrorReadable` is intentionally **out of scope** per the issue.

## Test plan

- [x] `CI=true swift test` passes (200 tests, 15 suites, 0 failures locally).
- [x] `rg -n '(\.first\s*\{[^}]*\}\!|as\!\s+(MaxLength|MinLength|CastRange|MaxCount|MinCount|OneOf|Description|Examples|Pattern|Precision|Count|Nullable|DefaultValue))' Tests/CastTests/{PropertyWrapper,NewWrapper}Tests.swift` returns zero hits.

Closes #96