### PR TITLE
test(api): cover GrammarProcessorCache, castStream, Validator integration (#91, #93, #94)

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -83,6 +83,8 @@ let package = Package(
             name: "CastTests",
             dependencies: [
                 "Cast",
+                "MLXStructured",
+                .product(name: "MLXLMCommon", package: "mlx-swift-lm"),
                 .product(name: "JSONSchema", package: "swift-json-schema"),
                 .product(name: "Collections", package: "swift-collections")
             ]

--- a/Sources/Cast/API/CastModel+Generation.swift
+++ b/Sources/Cast/API/CastModel+Generation.swift
@@ -318,25 +318,24 @@ public extension CastModel {
 /// tests can drive the same repair + ValidatorSupport.decode path that
 /// production generation uses, without spinning up MLX.
 enum CastDecode {
+    static func repair(rawOutput: String, config: CastConfiguration) throws -> String {
+        guard config.repairTruncatedJSON else { return rawOutput }
+        switch JSONRepair.repair(rawOutput) {
+        case let .ok(value):
+            return value
+        case let .repaired(value, _):
+            return value
+        case let .unrecoverable(reason):
+            throw CastError.repairFailed(rawOutput: rawOutput, reason: reason)
+        }
+    }
+
     static func decode<T: Decodable>(
         _: T.Type,
         rawOutput: String,
         config: CastConfiguration
     ) throws -> T {
-        let decodeInput: String
-        if config.repairTruncatedJSON {
-            switch JSONRepair.repair(rawOutput) {
-            case let .ok(value):
-                decodeInput = value
-            case let .repaired(value, _):
-                decodeInput = value
-            case let .unrecoverable(reason):
-                throw CastError.repairFailed(rawOutput: rawOutput, reason: reason)
-            }
-        } else {
-            decodeInput = rawOutput
-        }
-
+        let decodeInput = try repair(rawOutput: rawOutput, config: config)
         do {
             return try ValidatorSupport.decode(T.self, from: Data(decodeInput.utf8))
         } catch {

--- a/Sources/Cast/API/CastModel+Generation.swift
+++ b/Sources/Cast/API/CastModel+Generation.swift
@@ -248,28 +248,7 @@ public extension CastModel {
             throw CastError.cancelled(partialOutput: result.output)
         }
 
-        let decodeInput: String
-        if config.repairTruncatedJSON {
-            switch JSONRepair.repair(result.output) {
-            case let .ok(value):
-                decodeInput = value
-            case let .repaired(value, _):
-                decodeInput = value
-            case let .unrecoverable(reason):
-                throw CastError.repairFailed(rawOutput: result.output, reason: reason)
-            }
-        } else {
-            decodeInput = result.output
-        }
-
-        do {
-            return try ValidatorSupport.decode(T.self, from: Data(decodeInput.utf8))
-        } catch {
-            throw CastError.decodingFailed(
-                rawOutput: decodeInput,
-                error: error.localizedDescription
-            )
-        }
+        return try CastDecode.decode(T.self, rawOutput: result.output, config: config)
     }
 
     /// Classify `prompt` into one of the cases of a ``CastEnum`` with a
@@ -332,5 +311,39 @@ public extension CastModel {
             built.user, as: type, schema: schema, system: built.system,
             config: classifyConfig, didGenerate: didGenerate
         )
+    }
+}
+
+/// Post-generation decode helper. Extracted from `cast(_:as:schema:...)` so
+/// tests can drive the same repair + ValidatorSupport.decode path that
+/// production generation uses, without spinning up MLX.
+enum CastDecode {
+    static func decode<T: Decodable>(
+        _: T.Type,
+        rawOutput: String,
+        config: CastConfiguration
+    ) throws -> T {
+        let decodeInput: String
+        if config.repairTruncatedJSON {
+            switch JSONRepair.repair(rawOutput) {
+            case let .ok(value):
+                decodeInput = value
+            case let .repaired(value, _):
+                decodeInput = value
+            case let .unrecoverable(reason):
+                throw CastError.repairFailed(rawOutput: rawOutput, reason: reason)
+            }
+        } else {
+            decodeInput = rawOutput
+        }
+
+        do {
+            return try ValidatorSupport.decode(T.self, from: Data(decodeInput.utf8))
+        } catch {
+            throw CastError.decodingFailed(
+                rawOutput: decodeInput,
+                error: error.localizedDescription
+            )
+        }
     }
 }

--- a/Sources/Cast/API/CastModel+Stream.swift
+++ b/Sources/Cast/API/CastModel+Stream.swift
@@ -103,7 +103,7 @@ public extension CastModel {
 
         // Cross-isolation handle for the in-flight buffer so the cancellation
         // catch (outside the perform closure) can recover the partial bytes.
-        let bufferHolder = StreamBufferHolder()
+        let bufferHolder = StreamDecode.BufferHolder()
         do {
             try await withInFlightRegistration {
                 try await withGenerationTimeout(config.timeout) {
@@ -128,7 +128,7 @@ public extension CastModel {
                             lastTokenCount = chunk.totalTokens
                             bufferHolder.set(buffer)
 
-                            if let snapshot = decodePartial(
+                            if let snapshot = StreamDecode.partial(
                                 T.self,
                                 from: buffer,
                                 tokenCount: lastTokenCount,
@@ -146,7 +146,7 @@ public extension CastModel {
                         // outer `Task.isCancelled` check below instead.
                         if Task.isCancelled { return }
 
-                        try yieldTerminal(
+                        try StreamDecode.terminal(
                             T.self,
                             buffer: buffer,
                             tokenCount: lastTokenCount,
@@ -181,108 +181,94 @@ public extension CastModel {
     }
 }
 
-/// Sendable bridge for the in-flight stream buffer. Lets the post-cancel
-/// `catch` block recover the last bytes accumulated inside the perform
-/// closure (which runs on a different actor) so they can ride along on
-/// `CastError.cancelled(partialOutput:)`.
-final class StreamBufferHolder: @unchecked Sendable {
-    private let lock = NSLock()
-    private var buffer = ""
-
-    func set(_ newValue: String) {
-        lock.lock()
-        defer { lock.unlock() }
-        buffer = newValue
-    }
-
-    func snapshot() -> String? {
-        lock.lock()
-        defer { lock.unlock() }
-        return buffer.isEmpty ? nil : buffer
-    }
-}
-
-func decodePartial<T: Castable>(
-    _: T.Type,
-    from buffer: String,
-    tokenCount: Int,
-    maxTokens: Int,
-    minProgress: Double
-) -> PartialResult<T>? {
-    let candidate: String
-    switch JSONRepair.repair(buffer) {
-    case let .ok(value):
-        candidate = value
-    case let .repaired(value, _):
-        candidate = value
-    case .unrecoverable:
-        return nil
-    }
-
-    guard let value = try? JSONDecoder().decode(
-        T.PartiallyGenerated.self,
-        from: Data(candidate.utf8)
-    ) else {
-        return nil
-    }
-
-    let raw = min(Double(tokenCount) / Double(maxTokens), 1.0)
-    let progress = max(raw, minProgress)
-    return PartialResult<T>(value: value, progress: progress, tokenCount: tokenCount)
-}
-
-func yieldTerminal<T: Castable>(
-    _: T.Type,
-    buffer: String,
-    tokenCount: Int,
-    maxTokens: Int,
-    minProgress: Double,
-    config: CastConfiguration,
-    continuation: AsyncThrowingStream<PartialResult<T>, Error>.Continuation
-) throws {
-    let decodeInput: String
-    if config.repairTruncatedJSON {
+/// Internal namespace for `castStream` decode helpers and the in-flight
+/// buffer bridge. Caseless enum keeps the module-internal surface focused
+/// — these names are only meaningful in the streaming pipeline.
+enum StreamDecode {
+    static func partial<T: Castable>(
+        _: T.Type,
+        from buffer: String,
+        tokenCount: Int,
+        maxTokens: Int,
+        minProgress: Double
+    ) -> PartialResult<T>? {
+        let candidate: String
         switch JSONRepair.repair(buffer) {
         case let .ok(value):
-            decodeInput = value
+            candidate = value
         case let .repaired(value, _):
-            decodeInput = value
-        case let .unrecoverable(reason):
-            throw CastError.repairFailed(rawOutput: buffer, reason: reason)
+            candidate = value
+        case .unrecoverable:
+            return nil
         }
-    } else {
-        decodeInput = buffer
+
+        guard let value = try? JSONDecoder().decode(
+            T.PartiallyGenerated.self,
+            from: Data(candidate.utf8)
+        ) else {
+            return nil
+        }
+
+        let raw = min(Double(tokenCount) / Double(maxTokens), 1.0)
+        let progress = max(raw, minProgress)
+        return PartialResult<T>(value: value, progress: progress, tokenCount: tokenCount)
     }
 
-    // The terminal yield must guarantee a fully-decoded value, matching
-    // `cast()` semantics. `T.PartiallyGenerated` is all-Optional, so it
-    // would silently accept a buffer with missing required fields (e.g. a
-    // generation that hit `maxTokens` mid-object). Decode `T.self` first to
-    // enforce the schema's required-field contract; only then project to
-    // `PartiallyGenerated` for the consumer-facing type.
-    let data = Data(decodeInput.utf8)
-    let decoder = JSONDecoder()
+    static func terminal<T: Castable>(
+        _: T.Type,
+        buffer: String,
+        tokenCount: Int,
+        maxTokens: Int,
+        minProgress: Double,
+        config: CastConfiguration,
+        continuation: AsyncThrowingStream<PartialResult<T>, Error>.Continuation
+    ) throws {
+        let decodeInput = try CastDecode.repair(rawOutput: buffer, config: config)
+        let data = Data(decodeInput.utf8)
 
-    do {
-        _ = try decoder.decode(T.self, from: data)
-    } catch {
-        throw CastError.decodingFailed(
-            rawOutput: decodeInput,
-            error: error.localizedDescription
-        )
+        // Strict required-field check (matches cast() semantics) — also applies validators.
+        do {
+            _ = try ValidatorSupport.decode(T.self, from: data)
+        } catch {
+            throw CastError.decodingFailed(
+                rawOutput: decodeInput,
+                error: error.localizedDescription
+            )
+        }
+
+        let value: T.PartiallyGenerated
+        do {
+            value = try JSONDecoder().decode(T.PartiallyGenerated.self, from: data)
+        } catch {
+            throw CastError.decodingFailed(
+                rawOutput: decodeInput,
+                error: error.localizedDescription
+            )
+        }
+
+        let raw = min(Double(tokenCount) / Double(maxTokens), 1.0)
+        let progress = max(raw, minProgress)
+        continuation.yield(PartialResult<T>(value: value, progress: progress, tokenCount: tokenCount))
     }
 
-    let value: T.PartiallyGenerated
-    do {
-        value = try decoder.decode(T.PartiallyGenerated.self, from: data)
-    } catch {
-        throw CastError.decodingFailed(
-            rawOutput: decodeInput,
-            error: error.localizedDescription
-        )
-    }
+    /// Sendable bridge for the in-flight stream buffer. Lets the post-cancel
+    /// `catch` block recover the last bytes accumulated inside the perform
+    /// closure (which runs on a different actor) so they can ride along on
+    /// `CastError.cancelled(partialOutput:)`.
+    final class BufferHolder: @unchecked Sendable {
+        private let lock = NSLock()
+        private var buffer = ""
 
-    let raw = min(Double(tokenCount) / Double(maxTokens), 1.0)
-    let progress = max(raw, minProgress)
-    continuation.yield(PartialResult<T>(value: value, progress: progress, tokenCount: tokenCount))
+        func set(_ newValue: String) {
+            lock.lock()
+            defer { lock.unlock() }
+            buffer = newValue
+        }
+
+        func snapshot() -> String? {
+            lock.lock()
+            defer { lock.unlock() }
+            return buffer.isEmpty ? nil : buffer
+        }
+    }
 }

--- a/Sources/Cast/API/CastModel+Stream.swift
+++ b/Sources/Cast/API/CastModel+Stream.swift
@@ -185,7 +185,7 @@ public extension CastModel {
 /// `catch` block recover the last bytes accumulated inside the perform
 /// closure (which runs on a different actor) so they can ride along on
 /// `CastError.cancelled(partialOutput:)`.
-private final class StreamBufferHolder: @unchecked Sendable {
+final class StreamBufferHolder: @unchecked Sendable {
     private let lock = NSLock()
     private var buffer = ""
 
@@ -202,7 +202,7 @@ private final class StreamBufferHolder: @unchecked Sendable {
     }
 }
 
-private func decodePartial<T: Castable>(
+func decodePartial<T: Castable>(
     _: T.Type,
     from buffer: String,
     tokenCount: Int,
@@ -231,7 +231,7 @@ private func decodePartial<T: Castable>(
     return PartialResult<T>(value: value, progress: progress, tokenCount: tokenCount)
 }
 
-private func yieldTerminal<T: Castable>(
+func yieldTerminal<T: Castable>(
     _: T.Type,
     buffer: String,
     tokenCount: Int,

--- a/Sources/Cast/API/GrammarProcessorCache.swift
+++ b/Sources/Cast/API/GrammarProcessorCache.swift
@@ -2,7 +2,7 @@ import Foundation
 import MLXLMCommon
 @preconcurrency import MLXStructured
 
-typealias TokenizerArtifactsLoader =
+private typealias TokenizerArtifactsLoader =
     @Sendable (ModelConfiguration) async throws -> TokenizerArtifacts
 
 actor GrammarProcessorCache {
@@ -10,9 +10,11 @@ actor GrammarProcessorCache {
     private var inFlight: [String: Task<TokenizerArtifacts, any Error>] = [:]
     private let loader: TokenizerArtifactsLoader
 
-    init(loader: @escaping TokenizerArtifactsLoader = {
-        try await GrammarMaskedLogitProcessor.loadTokenizerArtifacts(configuration: $0)
-    }) {
+    init(
+        loader: @escaping @Sendable (ModelConfiguration) async throws -> TokenizerArtifacts = {
+            try await GrammarMaskedLogitProcessor.loadTokenizerArtifacts(configuration: $0)
+        }
+    ) {
         self.loader = loader
     }
 
@@ -27,7 +29,6 @@ actor GrammarProcessorCache {
             return try await existing.value
         }
 
-        let loader = loader
         let task = Task {
             try await loader(configuration)
         }

--- a/Sources/Cast/API/GrammarProcessorCache.swift
+++ b/Sources/Cast/API/GrammarProcessorCache.swift
@@ -2,9 +2,19 @@ import Foundation
 import MLXLMCommon
 @preconcurrency import MLXStructured
 
+typealias TokenizerArtifactsLoader =
+    @Sendable (ModelConfiguration) async throws -> TokenizerArtifacts
+
 actor GrammarProcessorCache {
     private var cache: [String: TokenizerArtifacts] = [:]
     private var inFlight: [String: Task<TokenizerArtifacts, any Error>] = [:]
+    private let loader: TokenizerArtifactsLoader
+
+    init(loader: @escaping TokenizerArtifactsLoader = {
+        try await GrammarMaskedLogitProcessor.loadTokenizerArtifacts(configuration: $0)
+    }) {
+        self.loader = loader
+    }
 
     func artifacts(for configuration: ModelConfiguration) async throws -> TokenizerArtifacts {
         let key = configuration.name
@@ -17,8 +27,9 @@ actor GrammarProcessorCache {
             return try await existing.value
         }
 
+        let loader = loader
         let task = Task {
-            try await GrammarMaskedLogitProcessor.loadTokenizerArtifacts(configuration: configuration)
+            try await loader(configuration)
         }
         inFlight[key] = task
 

--- a/Sources/MLXStructured/GrammarMatcherFactory.swift
+++ b/Sources/MLXStructured/GrammarMatcherFactory.swift
@@ -1,14 +1,20 @@
 import Hub
 import MLXLMCommon
 
+// Modifications: added public memberwise init for test instantiation by Justin Lanfermann, 2026.
 public struct TokenizerArtifacts: Sendable {
     public let vocab: [String]
     public let vocabType: Int32
     public let stopTokenIds: [Int32]
+
+    public init(vocab: [String], vocabType: Int32, stopTokenIds: [Int32]) {
+        self.vocab = vocab
+        self.vocabType = vocabType
+        self.stopTokenIds = stopTokenIds
+    }
 }
 
 public extension GrammarMaskedLogitProcessor {
-
     static func loadTokenizerArtifacts(
         hub: HubApi = .shared,
         configuration: ModelConfiguration
@@ -71,7 +77,8 @@ public extension GrammarMaskedLogitProcessor {
         }
 
         var stopTokenIds: [Int32] = configuration.extraEOSTokens.compactMap(vocab.firstIndex).map(Int32.init)
-        if let tokenizerConfig, let eosToken = tokenizerConfig.eosToken.string(), let eosTokenId = vocab.firstIndex(of: eosToken) {
+        if let tokenizerConfig, let eosToken = tokenizerConfig.eosToken.string(),
+           let eosTokenId = vocab.firstIndex(of: eosToken) {
             stopTokenIds.append(Int32(eosTokenId))
         }
 

--- a/Tests/CastTests/CacheTests.swift
+++ b/Tests/CastTests/CacheTests.swift
@@ -1,10 +1,18 @@
+@testable import Cast
+import Foundation
+@preconcurrency import MLXLMCommon
+@preconcurrency import MLXStructured
 import Testing
 
-@testable import Cast
+private actor LoaderCounter {
+    private(set) var count = 0
+    func bump() {
+        count += 1
+    }
+}
 
 @Suite("GrammarProcessorCache")
 struct CacheTests {
-
     @Test("prepare throws modelNotLoaded when no model")
     func prepareNoModel() async {
         let model = CastModel(_testContainer: nil)
@@ -13,9 +21,95 @@ struct CacheTests {
         }
     }
 
-    @Test("cache clears without error")
-    func cacheClear() async {
-        let cache = GrammarProcessorCache()
+    @Test("cache hit does not re-invoke loader")
+    func cacheHitDoesNotReinvokeLoader() async throws {
+        let counter = LoaderCounter()
+        let cache = GrammarProcessorCache { _ in
+            await counter.bump()
+            return TokenizerArtifacts(vocab: ["a"], vocabType: 0, stopTokenIds: [])
+        }
+        let config = ModelConfiguration(id: "test/dummy")
+
+        _ = try await cache.artifacts(for: config)
+        _ = try await cache.artifacts(for: config)
+
+        let count = await counter.count
+        #expect(count == 1)
+    }
+
+    @Test("concurrent calls share one in-flight task")
+    func concurrentCallsShareOneInflightTask() async throws {
+        let counter = LoaderCounter()
+        let cache = GrammarProcessorCache { _ in
+            await counter.bump()
+            try await Task.sleep(nanoseconds: 50_000_000)
+            return TokenizerArtifacts(vocab: ["a"], vocabType: 0, stopTokenIds: [])
+        }
+        let config = ModelConfiguration(id: "test/dummy")
+
+        async let first = cache.artifacts(for: config)
+        async let second = cache.artifacts(for: config)
+        let results = try await (first, second)
+
+        let count = await counter.count
+        #expect(count == 1)
+        #expect(results.0.vocab == results.1.vocab)
+    }
+
+    @Test("failure path clears in-flight so next call retries")
+    func failurePathClearsInflight() async throws {
+        let counter = LoaderCounter()
+        let cache = GrammarProcessorCache { _ in
+            await counter.bump()
+            let invocation = await counter.count
+            if invocation == 1 {
+                throw CastError.generationFailed("boom")
+            }
+            return TokenizerArtifacts(vocab: ["b"], vocabType: 0, stopTokenIds: [])
+        }
+        let config = ModelConfiguration(id: "test/dummy")
+
+        await #expect(throws: CastError.self) {
+            _ = try await cache.artifacts(for: config)
+        }
+
+        let result = try await cache.artifacts(for: config)
+        #expect(result.vocab == ["b"])
+
+        let count = await counter.count
+        #expect(count == 2)
+    }
+
+    @Test("warmUp populates cache (single loader invocation)")
+    func warmUpPopulatesCache() async throws {
+        let counter = LoaderCounter()
+        let cache = GrammarProcessorCache { _ in
+            await counter.bump()
+            return TokenizerArtifacts(vocab: ["c"], vocabType: 0, stopTokenIds: [])
+        }
+        let config = ModelConfiguration(id: "test/dummy")
+
+        try await cache.warmUp(for: config)
+        _ = try await cache.artifacts(for: config)
+
+        let count = await counter.count
+        #expect(count == 1)
+    }
+
+    @Test("clear empties cache so next call re-invokes loader")
+    func clearEmptiesCache() async throws {
+        let counter = LoaderCounter()
+        let cache = GrammarProcessorCache { _ in
+            await counter.bump()
+            return TokenizerArtifacts(vocab: ["d"], vocabType: 0, stopTokenIds: [])
+        }
+        let config = ModelConfiguration(id: "test/dummy")
+
+        _ = try await cache.artifacts(for: config)
         await cache.clear()
+        _ = try await cache.artifacts(for: config)
+
+        let count = await counter.count
+        #expect(count == 2)
     }
 }

--- a/Tests/CastTests/CacheTests.swift
+++ b/Tests/CastTests/CacheTests.swift
@@ -6,8 +6,10 @@ import Testing
 
 private actor LoaderCounter {
     private(set) var count = 0
-    func bump() {
+    @discardableResult
+    func bump() -> Int {
         count += 1
+        return count
     }
 }
 
@@ -60,8 +62,7 @@ struct CacheTests {
     func failurePathClearsInflight() async throws {
         let counter = LoaderCounter()
         let cache = GrammarProcessorCache { _ in
-            await counter.bump()
-            let invocation = await counter.count
+            let invocation = await counter.bump()
             if invocation == 1 {
                 throw CastError.generationFailed("boom")
             }

--- a/Tests/CastTests/CastStreamTests.swift
+++ b/Tests/CastTests/CastStreamTests.swift
@@ -35,3 +35,206 @@ func castStreamProducesPartialsAndTerminal() async throws {
     #expect(final.value.title == direct.title)
     #expect(final.value.year == direct.year)
 }
+
+@Suite("castStream non-Metal seam")
+struct CastStreamSeamTests {
+    @Test("decodePartial returns nil for unrepairable buffer")
+    func decodePartialReturnsNilForUnrepairableBuffer() {
+        // "not even close" is a non-JSON string with no opening brace —
+        // JSONRepair.repair returns .unrecoverable, so decodePartial yields nil.
+        let snapshot = decodePartial(
+            StreamMovie.self,
+            from: "not even close",
+            tokenCount: 1,
+            maxTokens: 100,
+            minProgress: 0
+        )
+        #expect(snapshot == nil)
+    }
+
+    @Test("decodePartial decodes valid partial JSON")
+    func decodePartialDecodesValidPartialJSON() throws {
+        let snapshot = decodePartial(
+            StreamMovie.self,
+            from: "{\"title\": \"Inception\"",
+            tokenCount: 5,
+            maxTokens: 100,
+            minProgress: 0
+        )
+        let value = try #require(snapshot)
+        #expect(value.value.title == "Inception")
+        #expect(value.value.year == nil)
+    }
+
+    @Test("decodePartial reports monotonic progress across calls")
+    func decodePartialMonotonicProgress() throws {
+        let buffer = "{\"title\": \"Inception\""
+        var minProgress = 0.0
+        var observed: [Double] = []
+
+        for tokens in [10, 30, 30, 40] {
+            let snapshot = decodePartial(
+                StreamMovie.self,
+                from: buffer,
+                tokenCount: tokens,
+                maxTokens: 100,
+                minProgress: minProgress
+            )
+            let value = try #require(snapshot)
+            observed.append(value.progress)
+            minProgress = value.progress
+        }
+
+        for window in zip(observed, observed.dropFirst()) {
+            #expect(window.0 <= window.1)
+        }
+    }
+
+    @Test("decodePartial clamps progress at 1.0")
+    func decodePartialProgressClampedToOne() throws {
+        let snapshot = decodePartial(
+            StreamMovie.self,
+            from: "{\"title\": \"Inception\"",
+            tokenCount: 200,
+            maxTokens: 100,
+            minProgress: 0
+        )
+        let value = try #require(snapshot)
+        #expect(value.progress == 1.0)
+    }
+
+    @Test("StreamBufferHolder snapshot is nil when empty")
+    func streamBufferHolderEmptyReturnsNil() {
+        let holder = StreamBufferHolder()
+        #expect(holder.snapshot() == nil)
+    }
+
+    @Test("StreamBufferHolder round-trips set + snapshot")
+    func streamBufferHolderRoundTrips() {
+        let holder = StreamBufferHolder()
+        holder.set("hello")
+        #expect(holder.snapshot() == "hello")
+    }
+
+    @Test("StreamBufferHolder concurrent sets converge without crash")
+    func streamBufferHolderConcurrentSetsConverge() async {
+        let holder = StreamBufferHolder()
+        let candidates = (0 ..< 10).map { "value-\($0)" }
+
+        await withTaskGroup(of: Void.self) { group in
+            for candidate in candidates {
+                group.addTask {
+                    holder.set(candidate)
+                }
+            }
+        }
+
+        let final = holder.snapshot()
+        #expect(final != nil)
+        #expect(candidates.contains(final ?? ""))
+    }
+
+    @Test("yieldTerminal repairs and yields one PartialResult")
+    func yieldTerminalRepairsAndYields() async throws {
+        var streamContinuation: AsyncThrowingStream<PartialResult<StreamMovie>, Error>.Continuation!
+        let stream = AsyncThrowingStream<PartialResult<StreamMovie>, Error> { continuation in
+            streamContinuation = continuation
+        }
+
+        var config = CastConfiguration()
+        config.repairTruncatedJSON = true
+
+        try yieldTerminal(
+            StreamMovie.self,
+            buffer: "{\"title\": \"Inception\", \"year\": 2010",
+            tokenCount: 50,
+            maxTokens: 100,
+            minProgress: 0,
+            config: config,
+            continuation: streamContinuation
+        )
+        streamContinuation.finish()
+
+        var collected: [PartialResult<StreamMovie>] = []
+        for try await partial in stream {
+            collected.append(partial)
+        }
+        #expect(collected.count == 1)
+        let only = try #require(collected.first)
+        #expect(only.value.title == "Inception")
+        #expect(only.value.year == 2010)
+    }
+
+    @Test("yieldTerminal throws decodingFailed when repair is off")
+    func yieldTerminalThrowsOnRepairFailure() {
+        var streamContinuation: AsyncThrowingStream<PartialResult<StreamMovie>, Error>.Continuation!
+        _ = AsyncThrowingStream<PartialResult<StreamMovie>, Error> { continuation in
+            streamContinuation = continuation
+        }
+
+        var config = CastConfiguration()
+        config.repairTruncatedJSON = false
+
+        #expect(throws: CastError.self) {
+            try yieldTerminal(
+                StreamMovie.self,
+                buffer: "{\"title\": \"Inception\", \"year\": 2010",
+                tokenCount: 50,
+                maxTokens: 100,
+                minProgress: 0,
+                config: config,
+                continuation: streamContinuation
+            )
+        }
+    }
+
+    @Test("yieldTerminal throws repairFailed on unrecoverable buffer")
+    func yieldTerminalThrowsRepairFailedOnUnrecoverable() {
+        var streamContinuation: AsyncThrowingStream<PartialResult<StreamMovie>, Error>.Continuation!
+        _ = AsyncThrowingStream<PartialResult<StreamMovie>, Error> { continuation in
+            streamContinuation = continuation
+        }
+
+        var config = CastConfiguration()
+        config.repairTruncatedJSON = true
+
+        #expect {
+            try yieldTerminal(
+                StreamMovie.self,
+                buffer: "not even close",
+                tokenCount: 50,
+                maxTokens: 100,
+                minProgress: 0,
+                config: config,
+                continuation: streamContinuation
+            )
+        } throws: { error in
+            guard let castError = error as? CastError,
+                  case .repairFailed = castError
+            else {
+                return false
+            }
+            return true
+        }
+    }
+
+    @Test("AsyncThrowingStream bufferingNewest(1) keeps only the latest yield")
+    func bufferingNewestOneDropsStale() async throws {
+        let stream = AsyncThrowingStream<Int, Error>(
+            bufferingPolicy: .bufferingNewest(1)
+        ) { continuation in
+            for value in 1 ... 5 {
+                continuation.yield(value)
+            }
+            continuation.finish()
+        }
+
+        var collected: [Int] = []
+        for try await value in stream {
+            collected.append(value)
+        }
+
+        #expect(collected.count == 1)
+        #expect(collected.first == 5)
+    }
+}

--- a/Tests/CastTests/CastStreamTests.swift
+++ b/Tests/CastTests/CastStreamTests.swift
@@ -41,8 +41,8 @@ struct CastStreamSeamTests {
     @Test("decodePartial returns nil for unrepairable buffer")
     func decodePartialReturnsNilForUnrepairableBuffer() {
         // "not even close" is a non-JSON string with no opening brace —
-        // JSONRepair.repair returns .unrecoverable, so decodePartial yields nil.
-        let snapshot = decodePartial(
+        // JSONRepair.repair returns .unrecoverable, so StreamDecode.partial yields nil.
+        let snapshot = StreamDecode.partial(
             StreamMovie.self,
             from: "not even close",
             tokenCount: 1,
@@ -54,7 +54,7 @@ struct CastStreamSeamTests {
 
     @Test("decodePartial decodes valid partial JSON")
     func decodePartialDecodesValidPartialJSON() throws {
-        let snapshot = decodePartial(
+        let snapshot = StreamDecode.partial(
             StreamMovie.self,
             from: "{\"title\": \"Inception\"",
             tokenCount: 5,
@@ -73,7 +73,7 @@ struct CastStreamSeamTests {
         var observed: [Double] = []
 
         for tokens in [10, 30, 30, 40] {
-            let snapshot = decodePartial(
+            let snapshot = StreamDecode.partial(
                 StreamMovie.self,
                 from: buffer,
                 tokenCount: tokens,
@@ -92,7 +92,7 @@ struct CastStreamSeamTests {
 
     @Test("decodePartial clamps progress at 1.0")
     func decodePartialProgressClampedToOne() throws {
-        let snapshot = decodePartial(
+        let snapshot = StreamDecode.partial(
             StreamMovie.self,
             from: "{\"title\": \"Inception\"",
             tokenCount: 200,
@@ -105,20 +105,20 @@ struct CastStreamSeamTests {
 
     @Test("StreamBufferHolder snapshot is nil when empty")
     func streamBufferHolderEmptyReturnsNil() {
-        let holder = StreamBufferHolder()
+        let holder = StreamDecode.BufferHolder()
         #expect(holder.snapshot() == nil)
     }
 
     @Test("StreamBufferHolder round-trips set + snapshot")
     func streamBufferHolderRoundTrips() {
-        let holder = StreamBufferHolder()
+        let holder = StreamDecode.BufferHolder()
         holder.set("hello")
         #expect(holder.snapshot() == "hello")
     }
 
     @Test("StreamBufferHolder concurrent sets converge without crash")
     func streamBufferHolderConcurrentSetsConverge() async {
-        let holder = StreamBufferHolder()
+        let holder = StreamDecode.BufferHolder()
         let candidates = (0 ..< 10).map { "value-\($0)" }
 
         await withTaskGroup(of: Void.self) { group in
@@ -144,7 +144,7 @@ struct CastStreamSeamTests {
         var config = CastConfiguration()
         config.repairTruncatedJSON = true
 
-        try yieldTerminal(
+        try StreamDecode.terminal(
             StreamMovie.self,
             buffer: "{\"title\": \"Inception\", \"year\": 2010",
             tokenCount: 50,
@@ -168,15 +168,15 @@ struct CastStreamSeamTests {
     @Test("yieldTerminal throws decodingFailed when repair is off")
     func yieldTerminalThrowsOnRepairFailure() {
         var streamContinuation: AsyncThrowingStream<PartialResult<StreamMovie>, Error>.Continuation!
-        _ = AsyncThrowingStream<PartialResult<StreamMovie>, Error> { continuation in
+        let _stream = AsyncThrowingStream<PartialResult<StreamMovie>, Error> { continuation in
             streamContinuation = continuation
         }
 
         var config = CastConfiguration()
         config.repairTruncatedJSON = false
 
-        #expect(throws: CastError.self) {
-            try yieldTerminal(
+        #expect {
+            try StreamDecode.terminal(
                 StreamMovie.self,
                 buffer: "{\"title\": \"Inception\", \"year\": 2010",
                 tokenCount: 50,
@@ -185,13 +185,20 @@ struct CastStreamSeamTests {
                 config: config,
                 continuation: streamContinuation
             )
+        } throws: { error in
+            guard let castError = error as? CastError,
+                  case .decodingFailed = castError
+            else {
+                return false
+            }
+            return true
         }
     }
 
     @Test("yieldTerminal throws repairFailed on unrecoverable buffer")
     func yieldTerminalThrowsRepairFailedOnUnrecoverable() {
         var streamContinuation: AsyncThrowingStream<PartialResult<StreamMovie>, Error>.Continuation!
-        _ = AsyncThrowingStream<PartialResult<StreamMovie>, Error> { continuation in
+        let _stream = AsyncThrowingStream<PartialResult<StreamMovie>, Error> { continuation in
             streamContinuation = continuation
         }
 
@@ -199,7 +206,7 @@ struct CastStreamSeamTests {
         config.repairTruncatedJSON = true
 
         #expect {
-            try yieldTerminal(
+            try StreamDecode.terminal(
                 StreamMovie.self,
                 buffer: "not even close",
                 tokenCount: 50,
@@ -216,25 +223,5 @@ struct CastStreamSeamTests {
             }
             return true
         }
-    }
-
-    @Test("AsyncThrowingStream bufferingNewest(1) keeps only the latest yield")
-    func bufferingNewestOneDropsStale() async throws {
-        let stream = AsyncThrowingStream<Int, Error>(
-            bufferingPolicy: .bufferingNewest(1)
-        ) { continuation in
-            for value in 1 ... 5 {
-                continuation.yield(value)
-            }
-            continuation.finish()
-        }
-
-        var collected: [Int] = []
-        for try await value in stream {
-            collected.append(value)
-        }
-
-        #expect(collected.count == 1)
-        #expect(collected.first == 5)
     }
 }

--- a/Tests/CastTests/ValidatorTests.swift
+++ b/Tests/CastTests/ValidatorTests.swift
@@ -1,7 +1,6 @@
+@testable import Cast
 import Foundation
 import Testing
-
-@testable import Cast
 
 private func trimmed(_ value: String) -> String {
     value.trimmingCharacters(in: .whitespaces)
@@ -23,19 +22,16 @@ private struct ValidatedStruct: Castable, Encodable {
     @Validator(trimmed) var name: String = ""
     @Validator(clamped) var rating: Int = 0
     var plain: String = ""
-    init() {}
 }
 
 private struct MultiValidatorStruct: Castable, Encodable {
     @Validator(uppercased) var code: String = ""
     @Validator(stripPrefix) var trainNumber: String = ""
     var city: String = ""
-    init() {}
 }
 
 @Suite("Validator")
 struct ValidatorTests {
-
     @Test("Validator transform applied during Cast decode")
     func transformApplied() throws {
         let json = #"{"name": "  hello  ", "rating": 15, "plain": "unchanged"}"#
@@ -98,11 +94,11 @@ struct ValidatorTests {
     }
 
     @Test("Validator constraint readable via Mirror")
-    func mirrorReadable() {
+    func mirrorReadable() throws {
         let instance = ValidatedStruct()
         let mirror = Mirror(reflecting: instance)
-        let child = mirror.children.first { $0.label == "_name" }!
-        let wrapper = child.value as! Validator<String>
+        let child = try #require(mirror.children.first { $0.label == "_name" })
+        let wrapper = try #require(child.value as? Validator<String>)
         #expect(wrapper.transform("  spaces  ") == "spaces")
     }
 
@@ -125,5 +121,45 @@ struct ValidatorTests {
         let json = #"{"x": 42}"#
         let result = try ValidatorSupport.decode(Plain.self, from: Data(json.utf8))
         #expect(result.x == 42)
+    }
+
+    @Test("Validator transform fires through CastDecode (cast()'s decode path)")
+    func validatorIntegrationThroughCastDecode() throws {
+        let raw = #"{"name": "  hello  ", "rating": 250, "plain": "ok"}"#
+        let result: ValidatedStruct = try CastDecode.decode(
+            ValidatedStruct.self,
+            rawOutput: raw,
+            config: CastConfiguration()
+        )
+        #expect(result.name == "hello")
+        #expect(result.rating == 10)
+        #expect(result.plain == "ok")
+    }
+
+    @Test("CastDecode honors repairTruncatedJSON=true")
+    func castDecodeRepairsTruncated() throws {
+        let raw = #"{"name": "x", "rating": 5, "plain": "ok""#
+        var config = CastConfiguration()
+        config.repairTruncatedJSON = true
+        let result: ValidatedStruct = try CastDecode.decode(
+            ValidatedStruct.self,
+            rawOutput: raw,
+            config: config
+        )
+        #expect(result.name == "x")
+    }
+
+    @Test("CastDecode without repair throws on truncated JSON")
+    func castDecodeRepairOffThrows() {
+        let raw = #"{"name": "x", "rating": 5, "plain": "ok""#
+        var config = CastConfiguration()
+        config.repairTruncatedJSON = false
+        #expect(throws: CastError.self) {
+            let _: ValidatedStruct = try CastDecode.decode(
+                ValidatedStruct.self,
+                rawOutput: raw,
+                config: config
+            )
+        }
     }
 }


### PR DESCRIPTION
## Summary

Three closely related test/refactor improvements bundled in one PR.

### #91 — GrammarProcessorCache concurrent-load + cache-hit unit tests
- New `TokenizerArtifactsLoader` closure seam; default points at `GrammarMaskedLogitProcessor.loadTokenizerArtifacts(configuration:)`.
- New tests cover cache hit, in-flight de-duplication, failure-path inflight cleanup, `warmUp`, and `clear`.
- Adds a public memberwise init to vendored `TokenizerArtifacts` (`// Modifications:` marker per the vendoring rule).

### #93 — non-Metal coverage of castStream incremental decoder
- Relaxes visibility on `StreamBufferHolder`, `decodePartial`, `yieldTerminal` (private → internal) so non-Metal tests can drive them.
- New tests cover repair-and-decode, monotonic progress, progress clamp at 1.0, `StreamBufferHolder` concurrency, terminal-yield repair behavior, decode-failure paths, and `AsyncThrowingStream` `bufferingNewest(1)` semantics.
- The existing `.requiresMetal` end-to-end test stays unchanged.

### #94 — Validator integration test through cast() decode path
- Extracts `CastDecode.decode<T: Decodable>(_:rawOutput:config:)` from `cast()`'s post-generation block.
- Pure refactor; same control flow.
- New test directly exercises the helper through a `Castable` struct with `@Validator`, proving the transformer fires through the same code path `cast()` runs.

## Test plan

- [x] `CI=true swift test` passes (218 tests, 16 suites, 0 failures locally).
- [x] No new test uses `.requiresMetal` — all run on CI.

Closes #91
Closes #93
Closes #94