### PR TITLE
fix(safety): resolve Sendable capture in iOS background safety (#105)

### DIFF
--- a/Sources/Cast/API/CastModel+Lifecycle.swift
+++ b/Sources/Cast/API/CastModel+Lifecycle.swift
@@ -109,12 +109,13 @@ public extension CastModel {
                 Memory.clearCache()
             }
 
+            let observers = _LifecycleObservers(
+                didEnterBackground: didEnter,
+                willResignActive: willResign,
+                memoryWarning: memWarn
+            )
             _observers.withLock { dict in
-                dict[key] = _LifecycleObservers(
-                    didEnterBackground: didEnter,
-                    willResignActive: willResign,
-                    memoryWarning: memWarn
-                )
+                dict[key] = observers
             }
         }
 


### PR DESCRIPTION
## Summary

Fix three Swift 6 strict-concurrency errors that broke the iOS build of Cast (`enableBackgroundSafety()` in `CastModel+Lifecycle.swift`).

The `_observers.withLock { ... }` closure is `@Sendable`. It was constructing `_LifecycleObservers` inline, which captured three `any NSObjectProtocol` locals (`didEnter`, `willResign`, `memWarn`). `NSObjectProtocol` is not `Sendable`, so the captures were rejected.

Fix: build the `_LifecycleObservers` wrapper before the `withLock` call. The wrapper is `@unchecked Sendable` (already declared in this file), so the closure now captures only a Sendable value. Six lines of churn, no API or behavior change.

## Test plan

- [x] `swift test` passes locally (full suite, including `LifecycleTests`)
- [x] Type-system-driven correctness: a Sendable wrapper captured by a @Sendable closure is well-formed
- [ ] iOS Xcode build verified once #44 demo project is hooked into CI (next step)

Closes #105

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized internal lifecycle observer initialization for improved code efficiency. No user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->