### PR TITLE
fix(safety): close enableBackgroundSafety() observer-registration race (#114)

### DIFF
--- a/Sources/Cast/API/CastModel+Lifecycle.swift
+++ b/Sources/Cast/API/CastModel+Lifecycle.swift
@@ -75,11 +75,6 @@ public extension CastModel {
         /// No-op on macOS / non-UIKit platforms.
         func enableBackgroundSafety() {
             let key = ObjectIdentifier(self)
-            let already = _observers.withLock { dict in
-                dict[key] != nil
-            }
-            if already { return }
-
             let center = NotificationCenter.default
             let weakSelf = WeakBox(self)
 
@@ -114,8 +109,19 @@ public extension CastModel {
                 willResignActive: willResign,
                 memoryWarning: memWarn
             )
-            _observers.withLock { dict in
+
+            // Single atomic check-and-insert: prevents two concurrent callers
+            // from both passing a check then both registering observer trios.
+            let inserted = _observers.withLock { dict -> Bool in
+                guard dict[key] == nil else { return false }
                 dict[key] = observers
+                return true
+            }
+
+            if !inserted {
+                center.removeObserver(didEnter)
+                center.removeObserver(willResign)
+                center.removeObserver(memWarn)
             }
         }
 

--- a/Tests/CastTests/LifecycleTests.swift
+++ b/Tests/CastTests/LifecycleTests.swift
@@ -77,4 +77,37 @@ import Testing
         lock.lock(); let final = cancelled; lock.unlock()
         #expect(final == true)
     }
+
+    /// Regression for #114: concurrent enableBackgroundSafety() must not leak
+    /// orphan observers into NotificationCenter. After racing N enables and a
+    /// single disable, posting didEnterBackground must not reach the model.
+    @Test func enableBackgroundSafetyIsRaceSafe() async {
+        let model = CastModel()
+
+        await withTaskGroup(of: Void.self) { group in
+            for _ in 0 ..< 64 {
+                group.addTask { model.enableBackgroundSafety() }
+            }
+        }
+
+        model.disableBackgroundSafety()
+
+        let lock = NSLock()
+        nonisolated(unsafe) var fired = false
+        let id = UUID()
+        model._inFlight.withLock { dict in
+            dict[id] = {
+                lock.lock(); fired = true; lock.unlock()
+            }
+        }
+
+        NotificationCenter.default.post(
+            name: UIApplication.didEnterBackgroundNotification,
+            object: nil
+        )
+        try? await Task.sleep(for: .milliseconds(50))
+
+        lock.lock(); let final = fired; lock.unlock()
+        #expect(final == false)
+    }
 #endif


### PR DESCRIPTION
## Summary
- Close a check-then-insert race in `CastModel.enableBackgroundSafety()`. Two concurrent callers could each addObserver three times in `NotificationCenter`; the second writer would win `_observers[key]` and orphan the first trio, which then survived `disableBackgroundSafety()` and could keep firing `abortInFlight()` / `cleanupGPU()` after detach.
- Restructure to register observers first, then check-and-insert atomically inside a single `_observers.withLock`. On the loss path (entry already present) remove the just-registered observers. The lock window stays tiny and the public idempotency claim now holds under contention.
- Add an iOS-gated regression test (`enableBackgroundSafetyIsRaceSafe`) that races 64 `enableBackgroundSafety()` calls, calls `disableBackgroundSafety()`, then asserts a posted `didEnterBackgroundNotification` does not reach the model.

## Test plan
- [x] `swift build` clean.
- [x] `CI=true swift test --filter CastTests` — 199 tests pass.
- [ ] iOS-only regression test (`enableBackgroundSafetyIsRaceSafe`) skipped on macOS by `#if canImport(UIKit) && os(iOS)` — same gating as the existing `didEnterBackgroundCancelsInFlight`. Validates locally on an iOS simulator.

Closes #114

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed an issue where concurrent background safety operations could result in duplicate notification callbacks being delivered.

* **Tests**
  * Added regression test to verify background safety operations work correctly under concurrent access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->